### PR TITLE
Fix MCP host and add CORS middleware

### DIFF
--- a/src/ad_seller/interfaces/api/main.py
+++ b/src/ad_seller/interfaces/api/main.py
@@ -17,7 +17,9 @@ from datetime import datetime
 from typing import Any, Optional
 
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,7 @@ app = FastAPI(
     version="1.0.0",
     contact={"name": "IAB Tech Lab", "url": "https://iabtechlab.com"},
     license_info={"name": "Apache 2.0", "url": "https://www.apache.org/licenses/LICENSE-2.0"},
+    root_path_in_servers=False,
     openapi_tags=[
         {"name": "Core", "description": "Health check and API root"},
         {"name": "Products", "description": "Product catalog browsing"},
@@ -64,6 +67,21 @@ app = FastAPI(
 # =============================================================================
 # Lifecycle: start/stop background services
 # =============================================================================
+
+# Trust X-Forwarded-Proto / X-Forwarded-For from Cloud Run so that Starlette
+# generates https:// redirects instead of http:// ones behind the TLS proxy.
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+
+# Allow all browser-based clients — buyer UIs, claude.ai, SSP dashboards, etc.
+# The MCP Streamable HTTP protocol requires CORS for browser-originated requests.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
+    allow_credentials=False,
+    expose_headers=["*"],
+)
 
 _mcp_server_ref = None
 

--- a/src/ad_seller/interfaces/mcp_server.py
+++ b/src/ad_seller/interfaces/mcp_server.py
@@ -39,9 +39,13 @@ mcp = FastMCP(
         "and interact with buyer agents. On first connection, check setup status "
         "and offer the guided setup wizard if configuration is incomplete."
     ),
-    # When mounted at /mcp in FastAPI, streamable_http_path="/" makes the
-    # endpoint resolve to /mcp (not /mcp/mcp which is the default behaviour).
+    # streamable_http_path="/" so that when mounted at /mcp in FastAPI the
+    # endpoint resolves to /mcp (not /mcp/mcp which is the default).
     streamable_http_path="/",
+    # host="0.0.0.0" disables the auto DNS-rebinding protection that FastMCP
+    # applies when host is 127.0.0.1/localhost. That protection blocks requests
+    # from Cloud Run (Host header is the public *.run.app domain) with 421.
+    host="0.0.0.0",
 )
 
 

--- a/src/ad_seller/interfaces/mcp_server.py
+++ b/src/ad_seller/interfaces/mcp_server.py
@@ -39,6 +39,9 @@ mcp = FastMCP(
         "and interact with buyer agents. On first connection, check setup status "
         "and offer the guided setup wizard if configuration is incomplete."
     ),
+    # When mounted at /mcp in FastAPI, streamable_http_path="/" makes the
+    # endpoint resolve to /mcp (not /mcp/mcp which is the default behaviour).
+    streamable_http_path="/",
 )
 
 


### PR DESCRIPTION
Claude.ai (Connector Configuration)
Use the following endpoint for MCP integration:
https://host-url/mcp

Claude Desktop (Local MCP Server Configuration)
If you're running the MCP server locally, add this configuration:
"mcpServers": {
      "seller-agent-local": {                                                                                                  
        "command": "npx",
        "args": [
          "mcp-remote",
          "http://localhost:8002/mcp/"
        ]                                                                                                                      
      }
 }