### PR TITLE
Fix ruff lint violations introduced by PR #13 (ar-r82f.22)

### DIFF
--- a/src/ad_seller/clients/freewheel_adapter.py
+++ b/src/ad_seller/clients/freewheel_adapter.py
@@ -27,7 +27,6 @@ from .ad_server_base import (
     BookingResult,
 )
 from .freewheel_mcp_client import FreeWheelMCPClient
-from .freewheel_oauth import FreeWheelOAuthManager, build_oauth_mcp_url
 from .freewheel_normalizer import (
     micros_to_dollars,
     normalize_audience_segments,
@@ -35,6 +34,7 @@ from .freewheel_normalizer import (
     normalize_deal,
     normalize_inventory,
 )
+from .freewheel_oauth import FreeWheelOAuthManager, build_oauth_mcp_url
 
 logger = logging.getLogger(__name__)
 
@@ -65,16 +65,12 @@ class FreeWheelAdServerClient(AdServerClient):
 
     def _get_sh_oauth_manager(self) -> FreeWheelOAuthManager:
         if self._sh_oauth_manager is None:
-            self._sh_oauth_manager = FreeWheelOAuthManager.for_provider(
-                self._get_settings(), "sh"
-            )
+            self._sh_oauth_manager = FreeWheelOAuthManager.for_provider(self._get_settings(), "sh")
         return self._sh_oauth_manager
 
     def _get_bc_oauth_manager(self) -> FreeWheelOAuthManager:
         if self._bc_oauth_manager is None:
-            self._bc_oauth_manager = FreeWheelOAuthManager.for_provider(
-                self._get_settings(), "bc"
-            )
+            self._bc_oauth_manager = FreeWheelOAuthManager.for_provider(self._get_settings(), "bc")
         return self._bc_oauth_manager
 
     # =========================================================================

--- a/src/ad_seller/clients/freewheel_oauth.py
+++ b/src/ad_seller/clients/freewheel_oauth.py
@@ -354,7 +354,9 @@ class FreeWheelOAuthManager:
             webbrowser.open(authorize_url)
 
         try:
-            callback_params = await asyncio.to_thread(callback_server.wait_for_result, timeout_seconds)
+            callback_params = await asyncio.to_thread(
+                callback_server.wait_for_result, timeout_seconds
+            )
         finally:
             callback_server.server_close()
 


### PR DESCRIPTION
## Summary

Two auto-fixable ruff violations were introduced into `main` by PR #13 (FreeWheel OAuth PKCE migration). They block the Lint CI job, which in turn blocks PR #15 (the seller CI workflow fix) from reaching its pytest step in verification.

This PR fixes both with `ruff check --fix` + `ruff format`:

- `src/ad_seller/clients/freewheel_adapter.py` — **I001** unsorted imports (alphabetized)
- `src/ad_seller/clients/freewheel_oauth.py` — **W292** missing trailing newline

`ruff format` also reflowed two short multi-line calls in `freewheel_adapter.py` (joined onto single lines under the line-length limit) and re-wrapped one call in `freewheel_oauth.py`. No logic changes — purely cosmetic.

## Why this matters

PR #15 (ar-r82f.16) fixes the seller CI workflow so Polly's QA verification can run pytest. With main's Lint job currently failing, the workflow short-circuits before verification can complete. Merging this restores green Lint on main and unblocks #15's verification path.

## Verification

- `uvx ruff check src/ad_seller/clients/freewheel_*.py` — `All checks passed!`
- `uvx ruff check src/` — `All checks passed!`
- `git diff` confirms changes are scoped to the 2 freewheel files only (16 line changes total)

## Test plan

- [ ] CI Lint job: SUCCESS (target — was failing on main before this PR)
- [ ] CI Test job: may still fail due to ongoing shutdown-hang in seller CI (ar-r82f.16, separate issue) — not this PR's concern