### PR TITLE
Fix MANAGER_LLM_MODEL default to sonnet (ar-tujw)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,7 +148,7 @@ PREFERRED_DEAL_DISCOUNT_MAX=0.15
 # LLM Configuration
 # =============================================================================
 DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
-MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
+MANAGER_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
 


### PR DESCRIPTION
## Summary

- `MANAGER_LLM_MODEL` defaulted to `anthropic/claude-opus-4-20250514`, which does not support strict tools required by crewai 1.14.6
- Any manager-LLM-driven crew silently failed with HTTP 400: `'claude-opus-4-20250514' does not support strict tools`
- Changed to `anthropic/claude-sonnet-4-5-20250929` (parity with `DEFAULT_LLM_MODEL`)

Discovered during EOD smoke test 2026-05-29 (ar-r82f.15). Tracked as bead [ar-tujw].

## Test plan

- [ ] Copy `.env.example` to `.env`, set `ANTHROPIC_API_KEY`, and run a manager-LLM-driven seller crew end-to-end
- [ ] Confirm no HTTP 400 strict-tools errors from the Anthropic API
- [ ] Confirm `MANAGER_LLM_MODEL` in `.env.example` now reads `anthropic/claude-sonnet-4-5-20250929`

🤖 Generated with [Claude Code](https://claude.com/claude-code)