### PR TITLE
 Make LLM layer model-agnostic via CrewAI native providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Ad Seller System Configuration
 
-# Required: Anthropic API Key for CrewAI agents
-ANTHROPIC_API_KEY=your-api-key-here
+# LLM provider credential — used for whichever provider DEFAULT_LLM_MODEL selects
+LLM_API_KEY=your-api-key-here
 
 # OpenDirect Server Configuration
 # Default: Live IAB Tech Lab agentic-direct server (OpenDirect 2.1)
@@ -147,10 +147,30 @@ PREFERRED_DEAL_DISCOUNT_MAX=0.15
 # =============================================================================
 # LLM Configuration
 # =============================================================================
+# Models use "<provider>/<model>" form; the provider is auto-selected from the
+# prefix. DEFAULT_LLM_MODEL runs the specialist agents; MANAGER_LLM_MODEL runs
+# the Level-1 manager (set both equal to use one model everywhere).
 DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
 MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
+
+# For OpenAI-compatible endpoints (NVIDIA NIM, Ollama, vLLM, ...), set the
+# base URL and the request is sent over the native OpenAI client.
+# LLM_API_BASE=
+# LLM_API_VERSION=          # Azure only
+
+# --- NVIDIA NIM free hosted models (OpenAI-compatible) -----------------------
+# Free key (nvapi-...) from build.nvidia.com; pick a function-calling model.
+# LLM_API_KEY=nvapi-xxxxxxxx
+# LLM_API_BASE=https://integrate.api.nvidia.com/v1
+# DEFAULT_LLM_MODEL=mistralai/mistral-nemotron
+# MANAGER_LLM_MODEL=mistralai/mistral-nemotron
+
+# --- Local Ollama (no key required) ------------------------------------------
+# LLM_API_BASE=http://localhost:11434/v1
+# DEFAULT_LLM_MODEL=llama3
+# MANAGER_LLM_MODEL=llama3
 
 # =============================================================================
 # CrewAI Configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Unit tests
         env:
-          ANTHROPIC_API_KEY: test-key-for-ci
+          LLM_API_KEY: test-key-for-ci
           AD_BUYER_SRC_PATH: ${{ github.workspace }}/buyer-agent/src
           CREWAI_TELEMETRY_OPT_OUT: "true"
           LITELLM_TELEMETRY: "False"
@@ -47,7 +47,7 @@ jobs:
 
       - name: Integration tests
         env:
-          ANTHROPIC_API_KEY: test-key-for-ci
+          LLM_API_KEY: test-key-for-ci
           CREWAI_TELEMETRY_OPT_OUT: "true"
           LITELLM_TELEMETRY: "False"
         run: |

--- a/docs/guides/claude-desktop-setup.md
+++ b/docs/guides/claude-desktop-setup.md
@@ -44,7 +44,7 @@ For seller agents running on `localhost`:
       "command": "uvicorn",
       "args": ["ad_seller.interfaces.api.main:app", "--port", "8000"],
       "env": {
-        "ANTHROPIC_API_KEY": "your-key"
+        "LLM_API_KEY": "your-key"
       }
     }
   }

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -11,7 +11,7 @@ with case-insensitive variable names.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `ANTHROPIC_API_KEY` | `str` | **required*** | API key for your LLM provider (see [Supported Providers](#supported-providers)) |
+| `LLM_API_KEY` | `str` | **required*** | API key for your LLM provider — any provider (see [Switching Providers](#switching-providers)) |
 | `SELLER_ORGANIZATION_ID` | `str` | auto-generated | Your organization ID |
 | `SELLER_ORGANIZATION_NAME` | `str` | `"Default Publisher"` | Organization display name |
 | `SELLER_AGENT_NAME` | `str` | `"Ad Seller Agent"` | Agent name shown in discovery |
@@ -85,36 +85,70 @@ ad-seller freewheel-login --provider bc
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
+| `LLM_API_KEY` | `str` | `None` | Provider credential, applied to whichever provider the model selects. |
 | `DEFAULT_LLM_MODEL` | `str` | `"anthropic/claude-sonnet-4-5-20250929"` | Model for specialist agents (pricing, negotiation, etc.) |
-| `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
+| `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for the manager/orchestrator agent. Set equal to `DEFAULT_LLM_MODEL` to use one model everywhere. |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
+| `LLM_API_BASE` | `str` | `None` | Endpoint for OpenAI-compatible providers (NVIDIA NIM, Ollama, vLLM, ...). |
+| `LLM_API_VERSION` | `str` | `None` | API version, when the provider requires one (Azure). |
 
-### Supported Providers
+### Switching Providers
 
-The seller agent uses CrewAI's native provider integrations via `provider/model-name` format. No code changes are required to switch providers. Install the matching extra (e.g., `pip install "crewai[anthropic]"` or `pip install "crewai[openai]"`).
+The agent layer is **provider-agnostic** and uses CrewAI's **native provider SDKs** — no third-party router. The provider is selected from the `provider/model` prefix; you set one `LLM_API_KEY` for the chosen provider. Switching is two settings:
 
-| Provider | Model Format | API Key Variable | Install Extra |
-|----------|-------------|-----------------|---------------|
-| **Anthropic** (default) | `anthropic/claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` | `crewai[anthropic]` |
-| **OpenAI** | `openai/gpt-4o` | `OPENAI_API_KEY` | `crewai[openai]` |
-| **Google Gemini** | `gemini/gemini-2.0-flash` | `GOOGLE_API_KEY` | `crewai[gemini]` |
-| **Azure OpenAI** | `azure/my-deployment` | `AZURE_API_KEY`, `AZURE_API_BASE` | `crewai[azure]` |
-| **AWS Bedrock** | `bedrock/anthropic.claude-3-sonnet` | AWS credentials | `crewai[bedrock]` |
+1. Point `DEFAULT_LLM_MODEL` / `MANAGER_LLM_MODEL` at the model.
+2. Set `LLM_API_KEY` to that provider's credential.
 
-**Example — switching to OpenAI:**
+| Provider | Model | Notes |
+|----------|-------|-------|
+| **Anthropic** (default) | `anthropic/claude-sonnet-4-5-20250929` | native |
+| **OpenAI** | `openai/gpt-4o` | native |
+| **Google Gemini** | `gemini/gemini-1.5-pro` | native (needs the Google GenAI SDK installed) |
+| **NVIDIA NIM** | any NVIDIA model | set `LLM_API_BASE` (below) |
+| **Ollama** (local) | `llama3` | set `LLM_API_BASE=http://localhost:11434/v1` |
+| **vLLM / Groq / others** | provider's model id | OpenAI-compatible → set `LLM_API_BASE` |
+
+For any **OpenAI-compatible** endpoint, set `LLM_API_BASE` and the request is sent over CrewAI's native OpenAI client pointed at that URL.
+
+**Example — OpenAI:**
 
 ```bash
-# Install: pip install "crewai[openai]"
 DEFAULT_LLM_MODEL=openai/gpt-4o
 MANAGER_LLM_MODEL=openai/gpt-4o
-OPENAI_API_KEY=sk-xxxxx
+LLM_API_KEY=sk-xxxxx
 ```
 
-!!! note "Prompt Tuning"
-    Agent prompts are tuned and tested with Claude models. Other providers work but may produce different quality results. If you switch providers, test negotiation and pricing flows to verify acceptable output quality.
+**Example — NVIDIA NIM free hosted models:**
 
-For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/en/learn/litellm-removal-guide).
+NVIDIA Build offers 80+ models free on an OpenAI-compatible endpoint. Create a free
+NVIDIA Developer account, open any model at [build.nvidia.com](https://build.nvidia.com/)
+and click **Get API Key** (`nvapi-…`; ~40 req/min). Pick a function-calling-capable
+model (e.g. Mistral Nemotron) since the agents use tools.
+
+```bash
+LLM_API_KEY=nvapi-xxxxxxxx
+LLM_API_BASE=https://integrate.api.nvidia.com/v1
+DEFAULT_LLM_MODEL=mistralai/mistral-nemotron
+MANAGER_LLM_MODEL=mistralai/mistral-nemotron
+```
+
+**Example — local Ollama (no key required):**
+
+```bash
+LLM_API_BASE=http://localhost:11434/v1
+DEFAULT_LLM_MODEL=llama3
+MANAGER_LLM_MODEL=llama3
+```
+
+!!! note "Tool-calling matters"
+    The agents rely on function/tool calling. Native OpenAI/Anthropic/Gemini and NVIDIA's
+    larger models support it well; some small local models do not, which degrades agent
+    behavior regardless of configuration. Prefer a function-calling-capable model.
+
+!!! note "Prompt Tuning"
+    Agent prompts are tuned and tested with Claude models. Other providers work but may
+    produce different quality results — test the negotiation and pricing flows after switching.
 
 ## Database & Storage
 
@@ -205,11 +239,10 @@ For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/
 
 ```bash
 # =============================================================================
-# LLM Provider (set the key for your chosen provider)
+# LLM Provider
 # =============================================================================
-ANTHROPIC_API_KEY=sk-ant-api03-xxxxxxxxxxxxxxxxxxxxx
-# OPENAI_API_KEY=sk-xxxxx                   # For OpenAI / Azure
-# COHERE_API_KEY=xxxxx                      # For Cohere
+LLM_API_KEY=your-provider-api-key
+# LLM_API_BASE=                             # For NVIDIA NIM / Ollama / vLLM
 
 # =============================================================================
 # Seller Identity

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -35,7 +35,7 @@ The app container reads from `../../.env` (project root). Key production setting
 STORAGE_TYPE=hybrid                    # Routes keys to Postgres or Redis
 DATABASE_URL=postgresql+asyncpg://seller:seller@postgres:5432/ad_seller
 REDIS_URL=redis://redis:6379/0
-ANTHROPIC_API_KEY=sk-ant-...           # Or your chosen LLM provider key
+LLM_API_KEY=...                        # Credential for your chosen LLM provider
 ```
 
 See [Configuration](configuration.md) for the full variable reference.

--- a/docs/guides/developer-setup.md
+++ b/docs/guides/developer-setup.md
@@ -8,7 +8,7 @@ Set up the seller agent infrastructure, connect to ad servers and SSPs, and gene
 - Docker (for deployment)
 - Ad server credentials (GAM service account JSON or FreeWheel MCP URL)
 - SSP API keys (optional: PubMatic, Index Exchange, Magnite)
-- Anthropic API key
+- An LLM provider API key (any provider — see Configuration)
 
 ## Step 1: Deploy the Seller Agent
 
@@ -29,7 +29,7 @@ Create a `.env` file:
 
 ```env
 # Required
-ANTHROPIC_API_KEY=sk-ant-...
+LLM_API_KEY=...
 
 # Seller Identity
 SELLER_ORGANIZATION_NAME=Your Publisher Name

--- a/docs/guides/publisher-setup.md
+++ b/docs/guides/publisher-setup.md
@@ -27,7 +27,7 @@ If you prefer to configure manually (or need reference for what the wizard does)
 Before starting, ensure you have:
 
 - **Python 3.11+** installed
-- An **Anthropic API key** (`ANTHROPIC_API_KEY`) for the LLM-powered specialist agents
+- An **LLM provider API key** (`LLM_API_KEY`) for the LLM-powered specialist agents
 - (Optional) **Google Ad Manager** credentials or **FreeWheel** MCP URL for live inventory sync
 - (Optional) **SSP API keys** for PubMatic, Index Exchange, or Magnite
 - (Optional) A public URL for agent discovery if participating in the IAB AAMP ecosystem

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -202,7 +202,7 @@ The seller agent's MCP endpoint uses Server-Sent Events. Connections must stay o
 2. For local stdio config, check the `claude_desktop_config.json` — the `command` must be on your `PATH`.
 3. Open Claude Desktop's MCP log: **Settings > Developer > View Logs**.
 4. Look for lines starting with `[seller-agent]` — they will show the startup error.
-5. Common cause: missing `ANTHROPIC_API_KEY` in the `env` block of the config.
+5. Common cause: missing `LLM_API_KEY` in the `env` block of the config.
 
 ---
 

--- a/infra/aws/cloudformation/compute.yaml
+++ b/infra/aws/cloudformation/compute.yaml
@@ -62,10 +62,10 @@ Parameters:
     Type: String
     Default: /ad-seller/db-password
     Description: Name of the SSM SecureString holding the DB password
-  AnthropicAPIKeySSMParamName:
+  LLMAPIKeySSMParamName:
     Type: String
-    Default: /ad-seller/anthropic-api-key
-    Description: Name of the SSM SecureString holding the Anthropic API key
+    Default: /ad-seller/llm-api-key
+    Description: Name of the SSM SecureString holding the LLM provider API key
 
 # =============================================================================
 # Resources
@@ -113,7 +113,7 @@ Resources:
                   - ssm:GetParameter
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DBPasswordSSMParamName}"
-                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AnthropicAPIKeySSMParamName}"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${LLMAPIKeySSMParamName}"
               - Effect: Allow
                 Action:
                   - kms:Decrypt
@@ -207,8 +207,8 @@ Resources:
           Secrets:
             - Name: DB_PASSWORD
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${DBPasswordSSMParamName}"
-            - Name: ANTHROPIC_API_KEY
-              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AnthropicAPIKeySSMParamName}"
+            - Name: LLM_API_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${LLMAPIKeySSMParamName}"
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/infra/aws/cloudformation/main.yaml
+++ b/infra/aws/cloudformation/main.yaml
@@ -29,10 +29,10 @@ Parameters:
     Type: String
     Default: /ad-seller/db-password
     Description: SSM SecureString parameter name holding the Aurora master password
-  AnthropicAPIKeySSMParam:
+  LLMAPIKeySSMParam:
     Type: String
-    Default: /ad-seller/anthropic-api-key
-    Description: SSM SecureString parameter name holding the Anthropic API key
+    Default: /ad-seller/llm-api-key
+    Description: SSM SecureString parameter name holding the LLM provider API key
   VpcCidr:
     Type: String
     Default: "10.20.0.0/16"
@@ -109,7 +109,7 @@ Resources:
         ACMCertificateArn: !Ref ACMCertificateArn
         DesiredCount: !Ref DesiredCount
         DBPasswordSSMParamName: !Ref DBMasterPasswordSSMParam
-        AnthropicAPIKeySSMParamName: !Ref AnthropicAPIKeySSMParam
+        LLMAPIKeySSMParamName: !Ref LLMAPIKeySSMParam
       Tags:
         - Key: Project
           Value: ad-seller-system

--- a/infra/aws/terraform/modules/compute/main.tf
+++ b/infra/aws/terraform/modules/compute/main.tf
@@ -7,8 +7,8 @@ data "aws_caller_identity" "current" {}
 # -----------------------------------------------------------------------------
 # SSM Parameter data sources for secrets
 # -----------------------------------------------------------------------------
-data "aws_ssm_parameter" "anthropic_api_key" {
-  name = "/${var.name_prefix}/anthropic-api-key"
+data "aws_ssm_parameter" "llm_api_key" {
+  name = "/${var.name_prefix}/llm-api-key"
 }
 
 data "aws_ssm_parameter" "database_password" {
@@ -336,8 +336,8 @@ resource "aws_ecs_task_definition" "app" {
 
       secrets = [
         {
-          name      = "ANTHROPIC_API_KEY"
-          valueFrom = data.aws_ssm_parameter.anthropic_api_key.arn
+          name      = "LLM_API_KEY"
+          valueFrom = data.aws_ssm_parameter.llm_api_key.arn
         },
         {
           name      = "DATABASE_PASSWORD"

--- a/src/ad_seller/agents/level1/inventory_manager.py
+++ b/src/ad_seller/agents/level1/inventory_manager.py
@@ -8,9 +8,9 @@ It manages overall inventory strategy with a yield optimization objective
 function, evaluates proposals, and coordinates specialist agents.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import LLMRole, get_llm
 
 
 def create_inventory_manager() -> Agent:
@@ -26,13 +26,7 @@ def create_inventory_manager() -> Agent:
     Returns:
         Agent: Configured Inventory Manager agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.manager_llm_model,
-        temperature=0.3,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(role=LLMRole.MANAGER, temperature=0.3)
 
     return Agent(
         role="Inventory Manager",

--- a/src/ad_seller/agents/level2/ctv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/ctv_inventory_agent.py
@@ -7,9 +7,9 @@ Manages Connected TV and streaming advertising inventory including
 OTT apps, FAST channels, and household-targeted inventory.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_ctv_inventory_agent() -> Agent:
@@ -25,13 +25,7 @@ def create_ctv_inventory_agent() -> Agent:
     Returns:
         Agent: Configured CTV Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="CTV Inventory Specialist",

--- a/src/ad_seller/agents/level2/display_inventory_agent.py
+++ b/src/ad_seller/agents/level2/display_inventory_agent.py
@@ -7,9 +7,9 @@ Manages display advertising inventory including banners, rich media,
 and premium homepage takeovers.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_display_inventory_agent() -> Agent:
@@ -24,13 +24,7 @@ def create_display_inventory_agent() -> Agent:
     Returns:
         Agent: Configured Display Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="Display Inventory Specialist",

--- a/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
@@ -19,9 +19,9 @@ Two-mode operation:
   integration lands)
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_linear_tv_inventory_agent() -> Agent:
@@ -39,13 +39,7 @@ def create_linear_tv_inventory_agent() -> Agent:
     Returns:
         Agent: Configured Linear TV Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="Linear TV Inventory Specialist",

--- a/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
+++ b/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
@@ -7,9 +7,9 @@ Manages mobile application advertising inventory including iOS/Android
 SDK inventory, rewarded video, interstitials, and in-app bidding.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_mobile_app_inventory_agent() -> Agent:
@@ -27,13 +27,7 @@ def create_mobile_app_inventory_agent() -> Agent:
     Returns:
         Agent: Configured Mobile App Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="Mobile App Inventory Specialist",

--- a/src/ad_seller/agents/level2/native_inventory_agent.py
+++ b/src/ad_seller/agents/level2/native_inventory_agent.py
@@ -7,9 +7,9 @@ Manages native advertising inventory including in-feed placements,
 content recommendations, and sponsored content.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_native_inventory_agent() -> Agent:
@@ -25,13 +25,7 @@ def create_native_inventory_agent() -> Agent:
     Returns:
         Agent: Configured Native Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="Native Inventory Specialist",

--- a/src/ad_seller/agents/level2/video_inventory_agent.py
+++ b/src/ad_seller/agents/level2/video_inventory_agent.py
@@ -7,9 +7,9 @@ Manages web video advertising inventory including pre-roll, mid-roll,
 and outstream formats.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_video_inventory_agent() -> Agent:
@@ -24,13 +24,7 @@ def create_video_inventory_agent() -> Agent:
     Returns:
         Agent: Configured Video Inventory agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.5,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.5)
 
     return Agent(
         role="Video Inventory Specialist",

--- a/src/ad_seller/agents/level3/audience_validator_agent.py
+++ b/src/ad_seller/agents/level3/audience_validator_agent.py
@@ -9,9 +9,9 @@ UCP (User Context Protocol) for real-time audience matching.
 
 from typing import Any
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_audience_validator_agent(
@@ -39,13 +39,8 @@ def create_audience_validator_agent(
     Returns:
         Agent: Configured Audience Validator agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.2,  # Low temperature for accurate validation
-        max_tokens=settings.llm_max_tokens,
-    )
+    # Low temperature for accurate validation
+    llm = get_llm(temperature=0.2)
 
     return Agent(
         role="Audience Validation Specialist",

--- a/src/ad_seller/agents/level3/availability_agent.py
+++ b/src/ad_seller/agents/level3/availability_agent.py
@@ -7,9 +7,9 @@ Manages inventory forecasting, availability checking, and pacing
 across all inventory types.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_availability_agent() -> Agent:
@@ -24,13 +24,8 @@ def create_availability_agent() -> Agent:
     Returns:
         Agent: Configured Availability agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.2,  # Low temperature for accurate forecasting
-        max_tokens=settings.llm_max_tokens,
-    )
+    # Low temperature for accurate forecasting
+    llm = get_llm(temperature=0.2)
 
     return Agent(
         role="Availability & Forecasting Specialist",

--- a/src/ad_seller/agents/level3/pricing_agent.py
+++ b/src/ad_seller/agents/level3/pricing_agent.py
@@ -7,9 +7,9 @@ Manages rate cards, dynamic pricing, floor prices, and tiered
 pricing based on buyer identity.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_pricing_agent() -> Agent:
@@ -25,13 +25,8 @@ def create_pricing_agent() -> Agent:
     Returns:
         Agent: Configured Pricing agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.2,  # Low temperature for consistent pricing decisions
-        max_tokens=settings.llm_max_tokens,
-    )
+    # Low temperature for consistent pricing decisions
+    llm = get_llm(temperature=0.2)
 
     return Agent(
         role="Pricing Specialist",

--- a/src/ad_seller/agents/level3/proposal_review_agent.py
+++ b/src/ad_seller/agents/level3/proposal_review_agent.py
@@ -7,9 +7,9 @@ Evaluates incoming proposals, validates against products,
 and recommends accept/counter/reject decisions.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_proposal_review_agent() -> Agent:
@@ -25,13 +25,7 @@ def create_proposal_review_agent() -> Agent:
     Returns:
         Agent: Configured Proposal Review agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.3,
-        max_tokens=settings.llm_max_tokens,
-    )
+    llm = get_llm(temperature=0.3)
 
     return Agent(
         role="Proposal Review Specialist",

--- a/src/ad_seller/agents/level3/upsell_agent.py
+++ b/src/ad_seller/agents/level3/upsell_agent.py
@@ -7,9 +7,9 @@ Identifies opportunities to expand deals, cross-sell inventory,
 and propose alternatives when rejecting proposals.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
-from ...config import get_settings
+from ...llm import get_llm
 
 
 def create_upsell_agent() -> Agent:
@@ -25,13 +25,8 @@ def create_upsell_agent() -> Agent:
     Returns:
         Agent: Configured Upsell agent
     """
-    settings = get_settings()
-
-    llm = LLM(
-        model=settings.default_llm_model,
-        temperature=0.6,  # Higher temperature for creative suggestions
-        max_tokens=settings.llm_max_tokens,
-    )
+    # Higher temperature for creative suggestions
+    llm = get_llm(temperature=0.6)
 
     return Agent(
         role="Upsell & Cross-Sell Specialist",

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -23,9 +23,6 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # API Keys
-    anthropic_api_key: str
-
     # OpenDirect Configuration
     opendirect_base_url: str = "http://localhost:3000"
     opendirect_api_key: Optional[str] = None
@@ -35,10 +32,16 @@ class Settings(BaseSettings):
     default_protocol: str = "opendirect21"  # opendirect21, a2a
 
     # LLM Configuration
+    # Provider is selected by the model prefix ("<provider>/<model>"). One
+    # llm_api_key serves whichever provider is chosen. Set llm_api_base for
+    # OpenAI-compatible endpoints (NVIDIA NIM, Ollama, vLLM, ...).
     default_llm_model: str = "anthropic/claude-sonnet-4-5-20250929"
     manager_llm_model: str = "anthropic/claude-opus-4-20250514"
     llm_temperature: float = 0.3
     llm_max_tokens: int = 4096
+    llm_api_key: Optional[str] = None
+    llm_api_base: Optional[str] = None
+    llm_api_version: Optional[str] = None
 
     # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_seller.db"

--- a/src/ad_seller/llm/__init__.py
+++ b/src/ad_seller/llm/__init__.py
@@ -1,0 +1,8 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Provider-agnostic LLM construction for the agent layer."""
+
+from .factory import LLMFactory, LLMRole, get_llm
+
+__all__ = ["LLMFactory", "LLMRole", "get_llm"]

--- a/src/ad_seller/llm/factory.py
+++ b/src/ad_seller/llm/factory.py
@@ -1,0 +1,86 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Provider-agnostic LLM construction.
+
+CrewAI ships native provider SDKs (openai, anthropic, azure, bedrock, gemini,
+openai_compatible) and routes by the "<provider>/<model>" prefix. Any provider
+works by setting the model and llm_api_key — no third-party router. For
+OpenAI-compatible endpoints (NVIDIA NIM, Ollama, vLLM, ...) set llm_api_base and
+the request is sent over the native OpenAI-protocol client.
+"""
+
+from enum import Enum
+from functools import lru_cache
+from typing import Optional
+
+from crewai import LLM
+
+from ..config import Settings, get_settings
+
+# CrewAI's native OpenAI SDK client; with a base_url it drives any endpoint that
+# speaks the OpenAI wire format (NVIDIA NIM, Ollama, vLLM, Groq, ...).
+_OPENAI_COMPATIBLE_PROVIDER = "openai"
+
+
+class LLMRole(str, Enum):
+    """Which configured model a caller wants."""
+
+    DEFAULT = "default"
+    MANAGER = "manager"
+
+
+class LLMFactory:
+    """Builds :class:`crewai.LLM` instances from application settings."""
+
+    def __init__(self, settings: Optional[Settings] = None) -> None:
+        self._settings = settings or get_settings()
+
+    def create(
+        self,
+        role: LLMRole = LLMRole.DEFAULT,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> LLM:
+        """Create an ``LLM`` for the given role."""
+        settings = self._settings
+        kwargs: dict[str, object] = {
+            "model": self._model_for_role(role),
+            "temperature": (
+                temperature if temperature is not None else settings.llm_temperature
+            ),
+            "max_tokens": (
+                max_tokens if max_tokens is not None else settings.llm_max_tokens
+            ),
+        }
+        if settings.llm_api_key:
+            kwargs["api_key"] = settings.llm_api_key
+        if settings.llm_api_version:
+            kwargs["api_version"] = settings.llm_api_version
+
+        # A custom endpoint means an OpenAI-compatible provider; pin the native
+        # provider explicitly so routing never falls back off the native path.
+        if settings.llm_api_base:
+            kwargs["provider"] = _OPENAI_COMPATIBLE_PROVIDER
+            kwargs["base_url"] = settings.llm_api_base
+
+        return LLM(**kwargs)
+
+    def _model_for_role(self, role: LLMRole) -> str:
+        if role is LLMRole.MANAGER:
+            return self._settings.manager_llm_model
+        return self._settings.default_llm_model
+
+
+@lru_cache
+def _get_factory() -> LLMFactory:
+    return LLMFactory()
+
+
+def get_llm(
+    role: LLMRole = LLMRole.DEFAULT,
+    temperature: Optional[float] = None,
+    max_tokens: Optional[int] = None,
+) -> LLM:
+    """Return a configured ``LLM`` for the given role."""
+    return _get_factory().create(role=role, temperature=temperature, max_tokens=max_tokens)

--- a/src/ad_seller/services/setup_wizard.py
+++ b/src/ad_seller/services/setup_wizard.py
@@ -58,7 +58,7 @@ DEVELOPER_STEPS = [
         phase=WizardPhase.DEVELOPER,
         order=1,
         title="Deploy & Environment",
-        description="Set deployment target, ANTHROPIC_API_KEY, storage backend",
+        description="Set deployment target, LLM_API_KEY, storage backend",
         is_required=True,
     ),
     WizardStep(
@@ -183,7 +183,7 @@ class SetupWizard:
         settings = self._get_settings()
 
         # Auto-detect completed developer steps
-        if settings.anthropic_api_key:
+        if settings.llm_api_key:
             self._dev_steps["d1_environment"].status = WizardStepStatus.COMPLETED
         if settings.gam_network_code or settings.freewheel_sh_mcp_url:
             self._dev_steps["d2_ad_server"].status = WizardStepStatus.COMPLETED

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -103,7 +103,7 @@ def make_settings(**overrides) -> types.SimpleNamespace:
         "pubmatic_mcp_url": "",
         "index_exchange_api_url": "",
         "magnite_api_url": "",
-        "anthropic_api_key": "sk-test-dummy",
+        "llm_api_key": "sk-test-dummy",
         "database_url": "sqlite:///:memory:",
         "redis_url": None,
         "storage_type": "sqlite",

--- a/tests/integration/test_schema_drift_canonical.py
+++ b/tests/integration/test_schema_drift_canonical.py
@@ -18,7 +18,7 @@ import json
 import os
 from pathlib import Path
 
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+os.environ.setdefault("LLM_API_KEY", "test-key-for-unit-tests")
 
 import pytest
 

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -1,0 +1,99 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for the provider-agnostic LLM factory."""
+
+from ad_seller.config.settings import Settings
+from ad_seller.llm import LLMFactory, LLMRole, get_llm
+
+
+def _settings(**overrides) -> Settings:
+    """Build an isolated Settings instance that ignores any local .env file."""
+    return Settings(_env_file=None, **overrides)
+
+
+class TestNativeRouting:
+    """Provider is selected natively from the model prefix."""
+
+    def test_anthropic_prefix_routes_to_anthropic(self):
+        factory = LLMFactory(
+            settings=_settings(
+                default_llm_model="anthropic/claude-sonnet-4-5-20250929",
+                llm_api_key="sk-test",
+            )
+        )
+        llm = factory.create()
+        assert llm.model == "claude-sonnet-4-5-20250929"
+        assert llm.provider == "anthropic"
+
+    def test_openai_prefix_routes_to_openai(self):
+        factory = LLMFactory(
+            settings=_settings(default_llm_model="openai/gpt-4o", llm_api_key="sk-test")
+        )
+        llm = factory.create()
+        assert llm.model == "gpt-4o"
+        assert llm.provider == "openai"
+
+    def test_role_selects_model(self):
+        factory = LLMFactory(
+            settings=_settings(
+                default_llm_model="openai/gpt-4o",
+                manager_llm_model="openai/gpt-4o-mini",
+                llm_api_key="sk-test",
+            )
+        )
+        assert factory.create(role=LLMRole.DEFAULT).model == "gpt-4o"
+        assert factory.create(role=LLMRole.MANAGER).model == "gpt-4o-mini"
+
+
+class TestOpenAICompatibleRouting:
+    """A custom base_url drives any OpenAI-compatible endpoint natively."""
+
+    def test_nvidia_nim_routes_via_openai_with_base_url(self):
+        factory = LLMFactory(
+            settings=_settings(
+                default_llm_model="mistralai/mistral-nemotron",
+                llm_api_base="https://integrate.api.nvidia.com/v1",
+                llm_api_key="nvapi-test",
+            )
+        )
+        llm = factory.create()
+        # Unknown-to-CrewAI model name still routes natively (no LiteLLM fallback)
+        # because the base_url pins the OpenAI-protocol client.
+        assert llm.provider == "openai"
+        assert llm.model == "mistralai/mistral-nemotron"
+        assert llm.base_url == "https://integrate.api.nvidia.com/v1"
+
+    def test_local_ollama_needs_no_key(self, monkeypatch):
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        factory = LLMFactory(
+            settings=_settings(
+                default_llm_model="llama3",
+                llm_api_base="http://localhost:11434/v1",
+            )
+        )
+        llm = factory.create()
+        assert llm.provider == "openai"
+        assert llm.base_url == "http://localhost:11434/v1"
+
+
+class TestParameterPassthrough:
+    """Temperature, key, and api_version flow through to the LLM."""
+
+    def test_temperature_override_and_fallback(self):
+        factory = LLMFactory(
+            settings=_settings(llm_temperature=0.42, llm_api_key="sk-test")
+        )
+        assert factory.create(temperature=0.9).temperature == 0.9
+        assert factory.create().temperature == 0.42
+
+    def test_api_key_passed_through(self):
+        factory = LLMFactory(settings=_settings(llm_api_key="sk-secret"))
+        assert factory.create().api_key == "sk-secret"
+
+
+def test_get_llm_convenience_returns_llm():
+    """The module-level helper returns a usable LLM for the default role."""
+    llm = get_llm(temperature=0.3)
+    assert llm is not None
+    assert llm.temperature == 0.3

--- a/tests/unit/test_modern_agentic_capabilities.py
+++ b/tests/unit/test_modern_agentic_capabilities.py
@@ -2,7 +2,7 @@
 
 import os
 
-os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
+os.environ.setdefault("LLM_API_KEY", "test-key-for-unit-tests")
 
 from ad_seller.models.audience_capabilities import (
     AgenticCapabilities,


### PR DESCRIPTION
Make the LLM layer model-agnostic so any provider can be configured via env (LLM_API_KEY + DEFAULT_LLM_MODEL / MANAGER_LLM_MODEL, plus LLM_API_BASE for OpenAI-compatible endpoints like NVIDIA NIM and Ollama). Uses CrewAI's native provider SDKs — no LiteLLM or third-party router.

Changes:
  - Add src/ad_seller/llm factory (get_llm/LLMFactory). Routes by model prefix to
    native OpenAI/Anthropic/Gemini; when LLM_API_BASE is set, pins the native
    OpenAI client at that URL.
  - settings: drop required anthropic_api_key; add llm_api_key, llm_api_base,
    llm_api_version; keep the default/manager two-tier model split.
  - Refactor all 12 agents to use get_llm().
  - Migrate ANTHROPIC_API_KEY -> LLM_API_KEY across env, setup wizard, CI, docs,
    and Terraform/CloudFormation; add NVIDIA NIM + Ollama presets and provider docs.
  - Add tests/unit/test_llm_factory.py.

Testing: ruff check src/ clean; full unit suite 727 passed; verified end-to-end via POST /proposals with Anthropic and OpenAI.
