### PR TITLE
Disable crewai shutdown telemetry hang (ar-r82f.21)

### DIFF
--- a/src/ad_seller/__init__.py
+++ b/src/ad_seller/__init__.py
@@ -3,4 +3,6 @@
 
 """Ad Seller System - IAB OpenDirect 2.1 compliant publisher/SSP agent system."""
 
+from ad_seller import _telemetry_shim  # noqa: F401  # MUST be first import — ar-r82f.21
+
 __version__ = "0.1.0"

--- a/src/ad_seller/_telemetry_shim.py
+++ b/src/ad_seller/_telemetry_shim.py
@@ -1,0 +1,51 @@
+"""Telemetry / shutdown shim for crewai 1.14.6 (ar-r82f.21).
+
+Sets opt-out env vars *before* any crewai / chromadb / posthog / opentelemetry
+import path runs, so their constructors take the disabled branch instead of
+registering daemon threads and atexit handlers that hang the interpreter for
+~5 minutes on shutdown.
+
+This module must be imported BEFORE crewai. The `ad_seller/__init__.py` imports
+it as the very first statement.
+
+CLI entrypoints additionally call `os._exit(0)` after `app()` returns to bypass
+any straggling atexit handlers that snuck in via transitive deps.
+"""
+
+from __future__ import annotations
+
+import os
+
+_TELEMETRY_ENV = {
+    "OTEL_SDK_DISABLED": "true",
+    "CREWAI_DISABLE_TELEMETRY": "true",
+    "CREWAI_DISABLE_TRACKING": "true",
+    "CREWAI_TELEMETRY_OPT_OUT": "true",
+    "ANONYMIZED_TELEMETRY": "false",
+    "POSTHOG_DISABLED": "true",
+    "CHROMA_TELEMETRY_DISABLED": "true",
+    "DO_NOT_TRACK": "1",
+}
+
+for _k, _v in _TELEMETRY_ENV.items():
+    os.environ.setdefault(_k, _v)
+
+
+def force_exit_after(callable_):
+    """Wrap a typer/click entrypoint so the process hard-exits on return.
+
+    Usage in CLI main:
+        if __name__ == "__main__":
+            force_exit_after(app)()
+    """
+
+    def _wrapped(*args, **kwargs):
+        try:
+            result = callable_(*args, **kwargs)
+            os._exit(0)
+            return result
+        except SystemExit as e:
+            code = e.code if isinstance(e.code, int) else 0
+            os._exit(code)
+
+    return _wrapped

--- a/src/ad_seller/interfaces/cli/main.py
+++ b/src/ad_seller/interfaces/cli/main.py
@@ -337,4 +337,10 @@ def chat():
 
 
 if __name__ == "__main__":
-    app()
+    import os
+    import sys
+    try:
+        app()
+    except SystemExit as e:
+        os._exit(e.code if isinstance(e.code, int) else 0)
+    os._exit(0)

--- a/src/ad_seller/interfaces/cli/main.py
+++ b/src/ad_seller/interfaces/cli/main.py
@@ -338,7 +338,7 @@ def chat():
 
 if __name__ == "__main__":
     import os
-    import sys
+
     try:
         app()
     except SystemExit as e:


### PR DESCRIPTION
## Bug

crewai 1.14.6 transitively imports chromadb and posthog at startup. Both
libraries register daemon threads and `atexit` handlers that **do not
honor** any of the libraries' documented opt-out env vars during the
shutdown path. Result: every CLI invocation hangs ~5 minutes on interpreter
exit after the command completes.

Discovered 2026-05-29 during EOD smoke test (local fix in
`smoke-fix/ar-r82f.15-2026-05-29`). The workaround drops shutdown time
from ~5 min to <2 s.

## Fix

Two pieces, shipped as a conservative shim with no monkey-patching:

### 1. `src/ad_seller/_telemetry_shim.py` — env-var opt-outs at import time

Sets 8 documented opt-out env vars **before** crewai/chromadb/posthog get
imported transitively, so their module constructors take the disabled branch:

| Env var | Purpose |
|---|---|
| `OTEL_SDK_DISABLED=true` | OpenTelemetry SDK |
| `CREWAI_DISABLE_TELEMETRY=true` | crewAI telemetry |
| `CREWAI_DISABLE_TRACKING=true` | crewAI tracking |
| `CREWAI_TELEMETRY_OPT_OUT=true` | crewAI opt-out |
| `ANONYMIZED_TELEMETRY=false` | chromadb |
| `POSTHOG_DISABLED=true` | PostHog |
| `CHROMA_TELEMETRY_DISABLED=true` | chromadb |
| `DO_NOT_TRACK=1` | generic DNT |

Uses `os.environ.setdefault` so user-set values are never overridden.

### 2. `src/ad_seller/__init__.py` — import shim first

The shim is imported as the **very first line** of `ad_seller/__init__.py`
to guarantee it runs before any transitive crewai/chromadb/posthog import.

### 3. `src/ad_seller/interfaces/cli/main.py` — `os._exit(0)` wrapper

Even with the env vars set, some atexit handlers can sneak in via
transitive deps at runtime. The CLI `__main__` block wraps `app()` with
`os._exit(0)` to hard-exit after typer returns, bypassing any remaining
atexit handlers.

This only applies to the CLI entry point. uvicorn/FastAPI servers
(`interfaces/api/`) stay on their normal graceful exit path.

## Why `os._exit` is needed

CPython's shutdown sequence calls all `atexit` handlers registered after
the main thread finishes. If any handler blocks on a daemon thread that
itself is blocked waiting for a network connection (PostHog flush,
chromadb heartbeat), the process hangs indefinitely. `os._exit` skips all
atexit handlers, achieving the same result as SIGKILL without losing the
exit code.

The proper fix is crewAI honoring opt-out env vars in their shutdown path
(filed upstream). This shim is the pragmatic workaround until that lands.

## Scope

This PR is **only** the telemetry shim + force-exit wrapper.
The `memory=True → memory=False` bulk change is tracked separately under
bead ar-i84f.

This PR is the seller-side counterpart to the buyer-agent PR. It also
unblocks PR #15 (ar-r82f.16) which has been parked DRAFT pending this
fix landing on both sides.

## Verification

```
git diff main fix/telemetry-shim-ar-r82f-21 --stat
# src/ad_seller/__init__.py            |  2 ++
# src/ad_seller/_telemetry_shim.py     | 51 +++++++
# src/ad_seller/interfaces/cli/main.py |  8 +++++-
# 3 files changed, 60 insertions(+), 1 deletion(-)
```

bead: ar-r82f.21