### PR TITLE
Make agent memory respect crew_memory_enabled config (ar-i84f)

### DIFF
--- a/src/ad_seller/agents/level1/inventory_manager.py
+++ b/src/ad_seller/agents/level1/inventory_manager.py
@@ -68,6 +68,6 @@ def create_inventory_manager() -> Agent:
         5. **Diversification**: Avoid over-reliance on any single buyer or channel""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/ctv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/ctv_inventory_agent.py
@@ -65,6 +65,6 @@ def create_ctv_inventory_agent() -> Agent:
         - Availability Agent on forecasting streaming inventory""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/display_inventory_agent.py
+++ b/src/ad_seller/agents/level2/display_inventory_agent.py
@@ -57,6 +57,6 @@ def create_display_inventory_agent() -> Agent:
         You can delegate to Level 3 agents for detailed pricing and availability.""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
@@ -138,6 +138,6 @@ def create_linear_tv_inventory_agent() -> Agent:
         - Video Inventory Agent on in-stream video companion opportunities""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
+++ b/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
@@ -68,6 +68,6 @@ def create_mobile_app_inventory_agent() -> Agent:
         - Proposal Review Agent on app install campaign evaluations""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/native_inventory_agent.py
+++ b/src/ad_seller/agents/level2/native_inventory_agent.py
@@ -65,6 +65,6 @@ def create_native_inventory_agent() -> Agent:
         - Proposal Review Agent on sponsored content requirements""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level2/video_inventory_agent.py
+++ b/src/ad_seller/agents/level2/video_inventory_agent.py
@@ -61,6 +61,6 @@ def create_video_inventory_agent() -> Agent:
         strategies and with the Pricing Agent on video-specific rate cards.""",
         verbose=True,
         allow_delegation=True,
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level3/audience_validator_agent.py
+++ b/src/ad_seller/agents/level3/audience_validator_agent.py
@@ -96,7 +96,7 @@ def create_audience_validator_agent(
         - Buyers' Audience Planner agents via UCP exchange""",
         verbose=verbose,
         allow_delegation=True,  # Can delegate to Inventory Specialists
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
         tools=tools or [],
     )

--- a/src/ad_seller/agents/level3/availability_agent.py
+++ b/src/ad_seller/agents/level3/availability_agent.py
@@ -68,6 +68,6 @@ def create_availability_agent() -> Agent:
         - Proposal Review Agent on deal feasibility""",
         verbose=True,
         allow_delegation=False,  # Availability checks are definitive
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level3/pricing_agent.py
+++ b/src/ad_seller/agents/level3/pricing_agent.py
@@ -71,6 +71,6 @@ def create_pricing_agent() -> Agent:
         - Proposal Review Agent on deal-specific pricing""",
         verbose=True,
         allow_delegation=False,  # Pricing decisions are final
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level3/proposal_review_agent.py
+++ b/src/ad_seller/agents/level3/proposal_review_agent.py
@@ -77,6 +77,6 @@ def create_proposal_review_agent() -> Agent:
         - Inventory Manager for final approval""",
         verbose=True,
         allow_delegation=True,  # Can delegate to Pricing/Availability
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )

--- a/src/ad_seller/agents/level3/upsell_agent.py
+++ b/src/ad_seller/agents/level3/upsell_agent.py
@@ -76,6 +76,6 @@ def create_upsell_agent() -> Agent:
         - Inventory Manager on strategic relationships""",
         verbose=True,
         allow_delegation=True,  # Can delegate to Inventory Specialists
-        memory=True,
+        memory=settings.crew_memory_enabled,
         llm=llm,
     )


### PR DESCRIPTION
## Summary

All 12 seller agent constructors hardcoded `memory=True`, ignoring `settings.crew_memory_enabled`. That hardcode forces crewai to attach a `search_memory` tool backed by chromadb + OpenAI embeddings, which fails at runtime when `CHROMA_OPENAI_API_KEY` is absent.

## Fix

Replace hardcoded `memory=True` with `memory=settings.crew_memory_enabled` in all 12 agent files:
- L1: `inventory_manager.py`
- L2: `ctv_inventory_agent`, `display_inventory_agent`, `linear_tv_inventory_agent`, `mobile_app_inventory_agent`, `native_inventory_agent`, `video_inventory_agent`
- L3: `audience_validator_agent`, `availability_agent`, `pricing_agent`, `proposal_review_agent`, `upsell_agent`

Settings default remains `crew_memory_enabled = True`, so users with an OpenAI embedder configured see no behavior change.

Mirrors the buyer-side fix at IABTechLab/buyer-agent#104.

## Context

Discovered 2026-05-29 during EOD smoke test (`ar-r82f.15`) Surface A.

bead: ar-i84f

🤖 Generated with [Claude Code](https://claude.com/claude-code)