### PR TITLE
Report failures before the pytest hard-exit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 """Pytest configuration and fixtures for Ad Seller System tests."""
 
 import os
+import sys
 
 import pytest
 
@@ -12,19 +13,39 @@ from ad_seller.models.core import DealType, PricingModel
 from ad_seller.models.flow_state import ProductDefinition
 from ad_seller.models.pricing_tiers import TieredPricingConfig
 
+_session_exit_status: int | None = None
+
 
 def pytest_sessionfinish(session, exitstatus):
-    """Hard-exit after the pytest session ends (ar-r82f.21).
+    """Record the exit status for the hard-exit in ``pytest_unconfigure``."""
+    global _session_exit_status
+    _session_exit_status = int(exitstatus)
+
+
+def pytest_unconfigure(config):
+    """Hard-exit after pytest has finished all reporting (ar-r82f.21).
 
     Even with ``_telemetry_shim.py`` setting every documented opt-out env
     var at import time, transitive deps (chromadb/posthog/opentelemetry)
     register atexit handlers that hang interpreter shutdown for ~5 min
     after pytest itself finishes. Our CLI entry point handles this with
     ``os._exit(0)`` after typer returns; pytest doesn't have an
-    equivalent path. This hook forces the same behaviour at the end of
-    a test session, after pytest's own reporting has fired.
+    equivalent path, so this hook forces the same behaviour.
+
+    The hard exit used to live in ``pytest_sessionfinish``, but the
+    terminal reporter prints the FAILURES section, short summary, and
+    stats line after the non-wrapper ``pytest_sessionfinish`` hooks run,
+    so exiting there ended every failing run with a bare ``F`` and no
+    diagnostics. ``pytest_unconfigure`` fires after all reporting is
+    done. ``os._exit`` also skips stdio flushing, which silently drops
+    any reporting still sitting in a block-buffered stream (the normal
+    case when output is redirected to a file or CI log), so both
+    streams are flushed first.
     """
-    os._exit(exitstatus)
+    if _session_exit_status is not None:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(_session_exit_status)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Any failing test run currently produces a bare `F` and exit code 1 with zero diagnostics, locally and in CI logs. The `os._exit` shutdown workaround in `tests/conftest.py` fires before pytest prints the FAILURES section, and it also drops buffered output. This PR keeps the workaround (the chromadb/posthog atexit hang it dodges is real) while restoring failure reporting.

## Before / after

Before, on a clean checkout (`pytest tests/unit/test_openrtb_parser.py -q`):

```
........F....                                                            [100%]
```

That is the entire output. After:

```
........F....                                                            [100%]
=================================== FAILURES ===================================
____________________ test_round_trip_builder_then_parser_recovers_refs ____________________
...
E               RuntimeError: Could not locate ad_seller_system in path ancestry ...
=========================== short test summary info ============================
FAILED tests/unit/test_openrtb_parser.py::test_round_trip_builder_then_parser_recovers_refs
1 failed, 12 passed in 0.09s
```

## Why two changes

1. **Hook placement**: the terminal reporter prints FAILURES, short summary, and the stats line after the non-wrapper `pytest_sessionfinish` hooks run, so hard-exiting there kills reporting. The exit now happens in `pytest_unconfigure`, which fires after all reporting; `pytest_sessionfinish` only records the exit status.
2. **Flush before `os._exit`**: `os._exit` skips stdio flushing, so with block-buffered output (file redirect, CI log capture) the report was lost even with correct hook order. Both streams are flushed first.

## Verification

- Failing run: full traceback, short summary, and stats now print; exit code 1 (was already correct and stays correct, preserving the behavior from #15).
- Full unit suite: completes in ~6 seconds with no shutdown hang, so the #21 workaround is intact.
- `ruff check` clean.

The failing test shown above is a separate fresh-clone issue; a follow-up PR ports the skip pattern buyer merged in buyer-agent#92.
