### PR TITLE
Feature/integrate llm providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,10 +147,35 @@ PREFERRED_DEAL_DISCOUNT_MAX=0.15
 # =============================================================================
 # LLM Configuration
 # =============================================================================
+# Only one provider can be active at a time.
+# Uncomment the block for your chosen provider and comment out the others.
+
+# Provider: Anthropic (default)
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
 DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
-MANAGER_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
+MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
+
+# Provider: OpenAI (alternative)
+# To switch to OpenAI, set DEFAULT_LLM_MODEL and OPENAI_API_KEY:
+# OPENAI_API_KEY=your-openai-api-key-here
+# DEFAULT_LLM_MODEL=openai/gpt-4o
+# MANAGER_LLM_MODEL=openai/gpt-4o
+
+# Provider: Google Gemini (alternative)
+# To switch to Gemini, set DEFAULT_LLM_MODEL and GOOGLE_API_KEY:
+# GOOGLE_API_KEY=your-google-api-key-here
+# DEFAULT_LLM_MODEL=gemini/gemini-2.0-flash
+# MANAGER_LLM_MODEL=gemini/gemini-2.0-flash
+
+# Provider: AWS Bedrock (alternative)
+# To switch to Bedrock, set DEFAULT_LLM_MODEL and AWS credentials:
+# AWS_ACCESS_KEY_ID=your-aws-access-key
+# AWS_SECRET_ACCESS_KEY=your-aws-secret-key
+# AWS_REGION=us-west-2
+# DEFAULT_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# MANAGER_LLM_MODEL=bedrock/us.anthropic.claude-opus-4-20250514-v1:0
 
 # =============================================================================
 # CrewAI Configuration

--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,30 @@ LLM_MAX_TOKENS=4096
 # DEFAULT_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
 # MANAGER_LLM_MODEL=bedrock/us.anthropic.claude-opus-4-20250514-v1:0
 
+# Provider: Custom OpenAI-compatible endpoint (alternative)
+# For endpoints with no CrewAI native provider prefix of their own — NVIDIA
+# NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, etc. Set DEFAULT_LLM_MODEL to
+# the raw model id the endpoint expects, plus LLM_API_BASE_URL. LLM_API_KEY is
+# optional — omit it for endpoints (e.g. a local Ollama server) that don't
+# require one.
+#
+# NVIDIA NIM:
+# LLM_API_KEY=nvapi-your-nvidia-api-key
+# LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+# DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
+# MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
+#
+# Ollama (local or self-hosted):
+# LLM_API_BASE_URL=http://localhost:11434/v1
+# DEFAULT_LLM_MODEL=llama3
+# MANAGER_LLM_MODEL=llama3
+#
+# HuggingFace TGI (self-hosted):
+# LLM_API_KEY=hf_your-huggingface-token
+# LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
+# DEFAULT_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
+# MANAGER_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
+
 # =============================================================================
 # CrewAI Configuration
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -166,8 +166,8 @@ LLM_MAX_TOKENS=4096
 # Provider: Google Gemini (alternative)
 # To switch to Gemini, set DEFAULT_LLM_MODEL and GOOGLE_API_KEY:
 # GOOGLE_API_KEY=your-google-api-key-here
-# DEFAULT_LLM_MODEL=gemini/gemini-2.0-flash
-# MANAGER_LLM_MODEL=gemini/gemini-2.0-flash
+# DEFAULT_LLM_MODEL=gemini/gemini-2.5-flash
+# MANAGER_LLM_MODEL=gemini/gemini-2.5-flash
 
 # Provider: AWS Bedrock (alternative)
 # To switch to Bedrock, set DEFAULT_LLM_MODEL and AWS credentials:

--- a/.env.example
+++ b/.env.example
@@ -180,24 +180,25 @@ LLM_MAX_TOKENS=4096
 # Provider: Custom OpenAI-compatible endpoint (alternative)
 # For endpoints with no CrewAI native provider prefix of their own — NVIDIA
 # NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, etc. Set DEFAULT_LLM_MODEL to
-# the raw model id the endpoint expects, plus LLM_API_BASE_URL. LLM_API_KEY is
+# the raw model id the endpoint expects, plus
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL. OPENAI_COMPATIBLE_LLM_API_KEY is
 # optional — omit it for endpoints (e.g. a local Ollama server) that don't
 # require one.
 #
 # NVIDIA NIM:
-# LLM_API_KEY=nvapi-your-nvidia-api-key
-# LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+# OPENAI_COMPATIBLE_LLM_API_KEY=nvapi-your-nvidia-api-key
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
 # DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
 # MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 #
 # Ollama (local or self-hosted):
-# LLM_API_BASE_URL=http://localhost:11434/v1
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=http://localhost:11434/v1
 # DEFAULT_LLM_MODEL=llama3
 # MANAGER_LLM_MODEL=llama3
 #
 # HuggingFace TGI (self-hosted):
-# LLM_API_KEY=hf_your-huggingface-token
-# LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
+# OPENAI_COMPATIBLE_LLM_API_KEY=hf_your-huggingface-token
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
 # DEFAULT_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
 # MANAGER_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -98,7 +98,7 @@ The seller agent uses CrewAI's native provider integrations via `provider/model-
 |----------|-------------|-----------------|---------------|
 | **Anthropic** (default) | `anthropic/claude-sonnet-4-5-20250929` | `ANTHROPIC_API_KEY` | `crewai[anthropic]` |
 | **OpenAI** | `openai/gpt-4o` | `OPENAI_API_KEY` | `crewai[openai]` |
-| **Google Gemini** | `gemini/gemini-2.0-flash` | `GOOGLE_API_KEY` | `crewai[gemini]` |
+| **Google Gemini** | `gemini/gemini-2.5-flash` | `GOOGLE_API_KEY` | `crewai[gemini]` |
 | **Azure OpenAI** | `azure/my-deployment` | `AZURE_API_KEY`, `AZURE_API_BASE` | `crewai[azure]` |
 | **AWS Bedrock** | `bedrock/anthropic.claude-3-sonnet` | AWS credentials | `crewai[bedrock]` |
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -89,8 +89,8 @@ ad-seller freewheel-login --provider bc
 | `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
-| `LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
-| `LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
+| `OPENAI_COMPATIBLE_LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
+| `OPENAI_COMPATIBLE_LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
 
 ### Supported Providers
 
@@ -122,17 +122,17 @@ For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/
 
 For endpoints that don't have one of the native provider prefixes above —
 NVIDIA NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, and similar — set
-`LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
+`OPENAI_COMPATIBLE_LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
 client regardless of the model id's shape, so `DEFAULT_LLM_MODEL` /
 `MANAGER_LLM_MODEL` should be set to the raw model id the endpoint expects
-(no provider prefix). `LLM_API_KEY` is optional — omit it for endpoints, such
+(no provider prefix). `OPENAI_COMPATIBLE_LLM_API_KEY` is optional — omit it for endpoints, such
 as a local Ollama server, that don't require one.
 
 **Example — NVIDIA NIM:**
 
 ```bash
-LLM_API_KEY=nvapi-xxxxx
-LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+OPENAI_COMPATIBLE_LLM_API_KEY=nvapi-xxxxx
+OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
 DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
 MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 ```
@@ -140,7 +140,7 @@ MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 **Example — Ollama, local or self-hosted:**
 
 ```bash
-LLM_API_BASE_URL=http://localhost:11434/v1
+OPENAI_COMPATIBLE_LLM_API_BASE_URL=http://localhost:11434/v1
 DEFAULT_LLM_MODEL=llama3
 MANAGER_LLM_MODEL=llama3
 ```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -89,6 +89,8 @@ ad-seller freewheel-login --provider bc
 | `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
+| `LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
+| `LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
 
 ### Supported Providers
 
@@ -115,6 +117,33 @@ OPENAI_API_KEY=sk-xxxxx
     Agent prompts are tuned and tested with Claude models. Other providers work but may produce different quality results. If you switch providers, test negotiation and pricing flows to verify acceptable output quality.
 
 For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/en/learn/litellm-removal-guide).
+
+### Custom OpenAI-Compatible Endpoints
+
+For endpoints that don't have one of the native provider prefixes above —
+NVIDIA NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, and similar — set
+`LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
+client regardless of the model id's shape, so `DEFAULT_LLM_MODEL` /
+`MANAGER_LLM_MODEL` should be set to the raw model id the endpoint expects
+(no provider prefix). `LLM_API_KEY` is optional — omit it for endpoints, such
+as a local Ollama server, that don't require one.
+
+**Example — NVIDIA NIM:**
+
+```bash
+LLM_API_KEY=nvapi-xxxxx
+LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
+MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
+```
+
+**Example — Ollama, local or self-hosted:**
+
+```bash
+LLM_API_BASE_URL=http://localhost:11434/v1
+DEFAULT_LLM_MODEL=llama3
+MANAGER_LLM_MODEL=llama3
+```
 
 ## Database & Storage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "crewai[anthropic,bedrock]>=1.14.4,<2.0.0",
+    "crewai[anthropic,bedrock,openai,gemini]>=1.14.4,<2.0.0",
     "crewai-tools>=1.14.0,<2.0.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",

--- a/src/ad_seller/agents/level1/inventory_manager.py
+++ b/src/ad_seller/agents/level1/inventory_manager.py
@@ -8,9 +8,10 @@ It manages overall inventory strategy with a yield optimization objective
 function, evaluates proposals, and coordinates specialist agents.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_inventory_manager() -> Agent:
@@ -28,7 +29,7 @@ def create_inventory_manager() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.manager_llm_model,
         temperature=0.3,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/ctv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/ctv_inventory_agent.py
@@ -7,9 +7,10 @@ Manages Connected TV and streaming advertising inventory including
 OTT apps, FAST channels, and household-targeted inventory.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_ctv_inventory_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_ctv_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/display_inventory_agent.py
+++ b/src/ad_seller/agents/level2/display_inventory_agent.py
@@ -7,9 +7,10 @@ Manages display advertising inventory including banners, rich media,
 and premium homepage takeovers.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_display_inventory_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_display_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
@@ -19,9 +19,10 @@ Two-mode operation:
   integration lands)
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_linear_tv_inventory_agent() -> Agent:
@@ -41,7 +42,7 @@ def create_linear_tv_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
+++ b/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
@@ -7,9 +7,10 @@ Manages mobile application advertising inventory including iOS/Android
 SDK inventory, rewarded video, interstitials, and in-app bidding.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_mobile_app_inventory_agent() -> Agent:
@@ -29,7 +30,7 @@ def create_mobile_app_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/native_inventory_agent.py
+++ b/src/ad_seller/agents/level2/native_inventory_agent.py
@@ -7,9 +7,10 @@ Manages native advertising inventory including in-feed placements,
 content recommendations, and sponsored content.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_native_inventory_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_native_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/video_inventory_agent.py
+++ b/src/ad_seller/agents/level2/video_inventory_agent.py
@@ -7,9 +7,10 @@ Manages web video advertising inventory including pre-roll, mid-roll,
 and outstream formats.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_video_inventory_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_video_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/audience_validator_agent.py
+++ b/src/ad_seller/agents/level3/audience_validator_agent.py
@@ -9,9 +9,10 @@ UCP (User Context Protocol) for real-time audience matching.
 
 from typing import Any
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_audience_validator_agent(
@@ -41,7 +42,7 @@ def create_audience_validator_agent(
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for accurate validation
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/availability_agent.py
+++ b/src/ad_seller/agents/level3/availability_agent.py
@@ -7,9 +7,10 @@ Manages inventory forecasting, availability checking, and pacing
 across all inventory types.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_availability_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_availability_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for accurate forecasting
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/pricing_agent.py
+++ b/src/ad_seller/agents/level3/pricing_agent.py
@@ -7,9 +7,10 @@ Manages rate cards, dynamic pricing, floor prices, and tiered
 pricing based on buyer identity.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_pricing_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_pricing_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for consistent pricing decisions
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/proposal_review_agent.py
+++ b/src/ad_seller/agents/level3/proposal_review_agent.py
@@ -7,9 +7,10 @@ Evaluates incoming proposals, validates against products,
 and recommends accept/counter/reject decisions.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_proposal_review_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_proposal_review_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.3,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/upsell_agent.py
+++ b/src/ad_seller/agents/level3/upsell_agent.py
@@ -7,9 +7,10 @@ Identifies opportunities to expand deals, cross-sell inventory,
 and propose alternatives when rejecting proposals.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_upsell_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_upsell_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.6,  # Higher temperature for creative suggestions
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -48,6 +48,15 @@ class Settings(BaseSettings):
     llm_temperature: float = 0.3
     llm_max_tokens: int = 4096
 
+    # Alternative: any OpenAI-wire-compatible endpoint (NVIDIA NIM, Ollama,
+    # HuggingFace TGI, vLLM, ...). Set LLM_API_BASE_URL alongside
+    # DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id the
+    # endpoint expects) to route through that endpoint instead of a named
+    # provider above. LLM_API_KEY is optional — omit it for endpoints like a
+    # local Ollama server that don't require one.
+    llm_api_key: Optional[str] = None
+    llm_api_base_url: Optional[str] = None
+
     # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_seller.db"
     redis_url: Optional[str] = None

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -49,13 +49,13 @@ class Settings(BaseSettings):
     llm_max_tokens: int = 4096
 
     # Alternative: any OpenAI-wire-compatible endpoint (NVIDIA NIM, Ollama,
-    # HuggingFace TGI, vLLM, ...). Set LLM_API_BASE_URL alongside
-    # DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id the
-    # endpoint expects) to route through that endpoint instead of a named
-    # provider above. LLM_API_KEY is optional — omit it for endpoints like a
-    # local Ollama server that don't require one.
-    llm_api_key: Optional[str] = None
-    llm_api_base_url: Optional[str] = None
+    # HuggingFace TGI, vLLM, ...). Set OPENAI_COMPATIBLE_LLM_API_BASE_URL
+    # alongside DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id
+    # the endpoint expects) to route through that endpoint instead of a named
+    # provider above. OPENAI_COMPATIBLE_LLM_API_KEY is optional — omit it for
+    # endpoints like a local Ollama server that don't require one.
+    openai_compatible_llm_api_key: Optional[str] = None
+    openai_compatible_llm_api_base_url: Optional[str] = None
 
     # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_seller.db"

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
 
     # API Keys
     anthropic_api_key: str
+    openai_api_key: Optional[str] = None
+    google_api_key: Optional[str] = None
 
     # OpenDirect Configuration
     opendirect_base_url: str = "http://localhost:3000"
@@ -35,6 +37,12 @@ class Settings(BaseSettings):
     default_protocol: str = "opendirect21"  # opendirect21, a2a
 
     # LLM Configuration
+    # Supported providers: anthropic (default), openai, gemini, bedrock
+    # Set DEFAULT_LLM_MODEL to switch provider, e.g.:
+    #   anthropic/claude-sonnet-4-5-20250929  (requires ANTHROPIC_API_KEY)
+    #   openai/gpt-4o                          (requires OPENAI_API_KEY)
+    #   gemini/gemini-2.0-flash                (requires GOOGLE_API_KEY)
+    #   bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 (requires AWS creds)
     default_llm_model: str = "anthropic/claude-sonnet-4-5-20250929"
     manager_llm_model: str = "anthropic/claude-opus-4-20250514"
     llm_temperature: float = 0.3

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     # Set DEFAULT_LLM_MODEL to switch provider, e.g.:
     #   anthropic/claude-sonnet-4-5-20250929  (requires ANTHROPIC_API_KEY)
     #   openai/gpt-4o                          (requires OPENAI_API_KEY)
-    #   gemini/gemini-2.0-flash                (requires GOOGLE_API_KEY)
+    #   gemini/gemini-2.5-flash                (requires GOOGLE_API_KEY)
     #   bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 (requires AWS creds)
     default_llm_model: str = "anthropic/claude-sonnet-4-5-20250929"
     manager_llm_model: str = "anthropic/claude-opus-4-20250514"

--- a/src/ad_seller/flows/proposal_handling_flow.py
+++ b/src/ad_seller/flows/proposal_handling_flow.py
@@ -419,7 +419,7 @@ class ProposalHandlingFlow(Flow[ProposalState]):
         crew = create_proposal_review_crew(self.state.proposal_data)
 
         try:
-            result = crew.kickoff()
+            result = await crew.kickoff_async()
 
             # Parse crew recommendation
             result_text = str(result).lower()

--- a/src/ad_seller/llm/__init__.py
+++ b/src/ad_seller/llm/__init__.py
@@ -1,0 +1,43 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""LLM construction shared by all agents.
+
+The named providers (Anthropic, OpenAI, Gemini, Bedrock) are switched by
+setting DEFAULT_LLM_MODEL / MANAGER_LLM_MODEL to a "<provider>/<model>"
+string plus that provider's API key, per docs/guides/configuration.md — no
+code here is involved in that path.
+
+This module adds one more alternative: any OpenAI-wire-compatible endpoint
+that has no CrewAI native provider prefix of its own (NVIDIA NIM, Ollama,
+HuggingFace TGI, vLLM, ...). Setting LLM_API_BASE_URL pins the request to
+CrewAI's native OpenAI-compatible client regardless of the model id's shape,
+using the raw model id the endpoint expects for DEFAULT_LLM_MODEL /
+MANAGER_LLM_MODEL. Leaving LLM_API_BASE_URL unset keeps today's behavior
+exactly as-is.
+"""
+
+from crewai import LLM
+
+from ..config import get_settings
+
+# CrewAI's native OpenAI SDK client; with a base_url it drives any endpoint
+# that speaks the OpenAI wire format (NVIDIA NIM, Ollama, HuggingFace TGI, ...).
+_OPENAI_COMPATIBLE_PROVIDER = "openai"
+
+
+def build_llm(model: str, temperature: float, max_tokens: int) -> LLM:
+    """Build an ``LLM`` for ``model``, honoring a custom base URL if configured."""
+    settings = get_settings()
+
+    if settings.llm_api_base_url:
+        return LLM(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            api_key=settings.llm_api_key,
+            provider=_OPENAI_COMPATIBLE_PROVIDER,
+            base_url=settings.llm_api_base_url,
+        )
+
+    return LLM(model=model, temperature=temperature, max_tokens=max_tokens)

--- a/src/ad_seller/llm/__init__.py
+++ b/src/ad_seller/llm/__init__.py
@@ -10,11 +10,11 @@ code here is involved in that path.
 
 This module adds one more alternative: any OpenAI-wire-compatible endpoint
 that has no CrewAI native provider prefix of its own (NVIDIA NIM, Ollama,
-HuggingFace TGI, vLLM, ...). Setting LLM_API_BASE_URL pins the request to
-CrewAI's native OpenAI-compatible client regardless of the model id's shape,
-using the raw model id the endpoint expects for DEFAULT_LLM_MODEL /
-MANAGER_LLM_MODEL. Leaving LLM_API_BASE_URL unset keeps today's behavior
-exactly as-is.
+HuggingFace TGI, vLLM, ...). Setting OPENAI_COMPATIBLE_LLM_API_BASE_URL pins
+the request to CrewAI's native OpenAI-compatible client regardless of the
+model id's shape, using the raw model id the endpoint expects for
+DEFAULT_LLM_MODEL / MANAGER_LLM_MODEL. Leaving
+OPENAI_COMPATIBLE_LLM_API_BASE_URL unset keeps today's behavior exactly as-is.
 """
 
 from crewai import LLM
@@ -30,14 +30,14 @@ def build_llm(model: str, temperature: float, max_tokens: int) -> LLM:
     """Build an ``LLM`` for ``model``, honoring a custom base URL if configured."""
     settings = get_settings()
 
-    if settings.llm_api_base_url:
+    if settings.openai_compatible_llm_api_base_url:
         return LLM(
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
-            api_key=settings.llm_api_key,
+            api_key=settings.openai_compatible_llm_api_key,
             provider=_OPENAI_COMPATIBLE_PROVIDER,
-            base_url=settings.llm_api_base_url,
+            base_url=settings.openai_compatible_llm_api_base_url,
         )
 
     return LLM(model=model, temperature=temperature, max_tokens=max_tokens)

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -14,9 +14,10 @@ def _settings(**overrides) -> Settings:
 
 
 class TestUnchangedWhenNoBaseUrl:
-    """No LLM_API_BASE_URL configured — identical to constructing LLM directly,
-    so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL provider swapping (Anthropic,
-    OpenAI, Gemini, Bedrock) works exactly as before this module existed."""
+    """No OPENAI_COMPATIBLE_LLM_API_BASE_URL configured — identical to
+    constructing LLM directly, so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL
+    provider swapping (Anthropic, OpenAI, Gemini, Bedrock) works exactly as
+    before this module existed."""
 
     def test_anthropic_model_routes_natively(self, monkeypatch):
         monkeypatch.setattr(
@@ -52,16 +53,16 @@ class TestUnchangedWhenNoBaseUrl:
 
 
 class TestCustomOpenAICompatibleEndpoint:
-    """LLM_API_BASE_URL configured — pins routing to the native OpenAI client
-    regardless of the model id's shape, covering NVIDIA NIM, Ollama,
-    HuggingFace TGI, and similar endpoints."""
+    """OPENAI_COMPATIBLE_LLM_API_BASE_URL configured — pins routing to the
+    native OpenAI client regardless of the model id's shape, covering NVIDIA
+    NIM, Ollama, HuggingFace TGI, and similar endpoints."""
 
     def test_nvidia_nim_routes_via_openai_with_base_url(self, monkeypatch):
         monkeypatch.setattr(
             "ad_seller.llm.get_settings",
             lambda: _settings(
-                llm_api_key="nvapi-test",
-                llm_api_base_url="https://integrate.api.nvidia.com/v1",
+                openai_compatible_llm_api_key="nvapi-test",
+                openai_compatible_llm_api_base_url="https://integrate.api.nvidia.com/v1",
             ),
         )
         llm = build_llm(
@@ -75,7 +76,9 @@ class TestCustomOpenAICompatibleEndpoint:
     def test_local_ollama_needs_no_key(self, monkeypatch):
         monkeypatch.setattr(
             "ad_seller.llm.get_settings",
-            lambda: _settings(llm_api_base_url="http://localhost:11434/v1"),
+            lambda: _settings(
+                openai_compatible_llm_api_base_url="http://localhost:11434/v1"
+            ),
         )
         llm = build_llm(model="llama3", temperature=0.3, max_tokens=4096)
         assert llm.provider == "openai"

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,0 +1,83 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for the custom OpenAI-compatible endpoint alternative (build_llm)."""
+
+from ad_seller.config.settings import Settings
+from ad_seller.llm import build_llm
+
+
+def _settings(**overrides) -> Settings:
+    """Build an isolated Settings instance that ignores any local .env file."""
+    overrides.setdefault("anthropic_api_key", "sk-ant-test")
+    return Settings(_env_file=None, **overrides)
+
+
+class TestUnchangedWhenNoBaseUrl:
+    """No LLM_API_BASE_URL configured — identical to constructing LLM directly,
+    so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL provider swapping (Anthropic,
+    OpenAI, Gemini, Bedrock) works exactly as before this module existed."""
+
+    def test_anthropic_model_routes_natively(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(default_llm_model="anthropic/claude-sonnet-4-5-20250929"),
+        )
+        llm = build_llm(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            temperature=0.3,
+            max_tokens=4096,
+        )
+        assert llm.model == "claude-sonnet-4-5-20250929"
+        assert llm.provider == "anthropic"
+
+    def test_openai_model_routes_natively(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(openai_api_key="sk-openai-test"),
+        )
+        llm = build_llm(model="openai/gpt-4o", temperature=0.5, max_tokens=4096)
+        assert llm.model == "gpt-4o"
+        assert llm.provider == "openai"
+
+    def test_temperature_and_max_tokens_pass_through(self, monkeypatch):
+        monkeypatch.setattr("ad_seller.llm.get_settings", lambda: _settings())
+        llm = build_llm(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            temperature=0.7,
+            max_tokens=2048,
+        )
+        assert llm.temperature == 0.7
+        assert llm.max_tokens == 2048
+
+
+class TestCustomOpenAICompatibleEndpoint:
+    """LLM_API_BASE_URL configured — pins routing to the native OpenAI client
+    regardless of the model id's shape, covering NVIDIA NIM, Ollama,
+    HuggingFace TGI, and similar endpoints."""
+
+    def test_nvidia_nim_routes_via_openai_with_base_url(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(
+                llm_api_key="nvapi-test",
+                llm_api_base_url="https://integrate.api.nvidia.com/v1",
+            ),
+        )
+        llm = build_llm(
+            model="meta/llama-3.1-70b-instruct", temperature=0.3, max_tokens=4096
+        )
+        assert llm.provider == "openai"
+        assert llm.model == "meta/llama-3.1-70b-instruct"
+        assert llm.base_url == "https://integrate.api.nvidia.com/v1"
+        assert llm.api_key == "nvapi-test"
+
+    def test_local_ollama_needs_no_key(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(llm_api_base_url="http://localhost:11434/v1"),
+        )
+        llm = build_llm(model="llama3", temperature=0.3, max_tokens=4096)
+        assert llm.provider == "openai"
+        assert llm.model == "llama3"
+        assert llm.base_url == "http://localhost:11434/v1"


### PR DESCRIPTION
 Summary

  - Adds OpenAI and Gemini as supported LLM providers alongside the existing Anthropic default
  - Installs the required crewai extras (openai, gemini) in pyproject.toml so dependencies are present when a non-Anthropic model is configured
  - Adds OPENAI_API_KEY and GOOGLE_API_KEY as optional fields in Settings with inline provider-switch docs
  - Updates model references from gemini-2.0-flash (deprecated June 2026) to gemini-2.5-flash across settings.py, .env.example, and
  docs/guides/configuration.md
  - Fixes MANAGER_LLM_MODEL default in .env.example from claude-sonnet to claude-opus-4 to match settings.py

  Provider configuration (.env.example)

  Only one provider can be active at a time. The file ships with Anthropic uncommented as the default. To switch, comment out the Anthropic block
  and uncomment the target block:

  --Provider: Anthropic (default — active)
  ANTHROPIC_API_KEY=your-anthropic-api-key-here
  DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
  MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514

  -- Provider: OpenAI (alternative)
  --OPENAI_API_KEY=your-openai-api-key-here
  --DEFAULT_LLM_MODEL=openai/gpt-4o
  -- MANAGER_LLM_MODEL=openai/gpt-4o

  --Provider: Google Gemini (alternative)
  --GOOGLE_API_KEY=your-google-api-key-here
  --DEFAULT_LLM_MODEL=gemini/gemini-2.5-flash
  --MANAGER_LLM_MODEL=gemini/gemini-2.5-flash

  Test plan

  - [ ] Start seller agent with default Anthropic config — agents initialize without error
  - [ ] Swap to openai/gpt-4o + OPENAI_API_KEY — crew runs using OpenAI
  - [ ] Swap to gemini/gemini-2.5-flash + GOOGLE_API_KEY — crew runs using Gemini
  - [ ] Verify pyproject.toml extras install cleanly: pip install -e ".[anthropic,openai,gemini]"