### PR TITLE
Fix mislabeled proposal recommendations via structured crew output

### DIFF
--- a/src/ad_seller/crews/inventory_crews.py
+++ b/src/ad_seller/crews/inventory_crews.py
@@ -25,6 +25,7 @@ from ..agents.level3 import (
     create_upsell_agent,
 )
 from ..config import get_settings
+from ..models.flow_state import ProposalReviewOutput
 from ..tools.audience import (
     AudienceCapabilityTool,
     AudienceValidationTool,
@@ -412,12 +413,13 @@ Synthesize all inputs and provide:
 - If Reject: Clear explanation and alternatives
 - Audience coverage impact on delivery confidence
 - Upsell opportunities to pursue""",
-        expected_output="""Final proposal recommendation with:
-- Decision (Accept/Counter/Reject)
-- Counter-terms if applicable (including audience modifications)
-- Rejection reason and alternatives if applicable
-- Audience validation summary
-- Prioritized upsell opportunities""",
+        expected_output="""A structured proposal decision with:
+- decision: accept, counter, or reject
+- rationale: brief explanation
+- counter_price_cpm and counter_terms if countering
+- rejection_reason if rejecting
+- audience_summary
+- upsell_opportunities""",
         agent=proposal_review_agent,
         context=[
             pricing_check_task,
@@ -425,6 +427,7 @@ Synthesize all inputs and provide:
             audience_validation_task,
             upsell_task,
         ],
+        output_pydantic=ProposalReviewOutput,
     )
 
     return Crew(

--- a/src/ad_seller/flows/proposal_handling_flow.py
+++ b/src/ad_seller/flows/proposal_handling_flow.py
@@ -27,6 +27,7 @@ from ..models.buyer_identity import BuyerContext
 from ..models.flow_state import (
     ExecutionStatus,
     ProposalEvaluation,
+    ProposalReviewOutput,
     SellerFlowState,
 )
 from ..models.ucp import AudienceCapability, SignalType
@@ -419,17 +420,13 @@ class ProposalHandlingFlow(Flow[ProposalState]):
         crew = create_proposal_review_crew(self.state.proposal_data)
 
         try:
-            result = crew.kickoff()
+            result = await crew.kickoff_async()
 
-            # Parse crew recommendation
-            result_text = str(result).lower()
-
-            if "accept" in result_text:
-                self.state.recommendation = "accept"
-            elif "counter" in result_text:
-                self.state.recommendation = "counter"
+            review: Optional[ProposalReviewOutput] = result.pydantic
+            if review is not None:
+                self.state.recommendation = review.decision.value
             else:
-                self.state.recommendation = "reject"
+                self._fallback_evaluation()
 
             # Emit proposal.evaluated event
             await emit_event(

--- a/src/ad_seller/models/flow_state.py
+++ b/src/ad_seller/models/flow_state.py
@@ -135,6 +135,36 @@ class ProposalEvaluation(BaseModel):
     upsell_opportunities: list[str] = Field(default_factory=list)
 
 
+class ProposalDecision(str, Enum):
+    """Final decision on a proposal, as returned by the review crew."""
+
+    ACCEPT = "accept"
+    COUNTER = "counter"
+    REJECT = "reject"
+
+
+class ProposalReviewOutput(BaseModel):
+    """Structured final decision from the proposal-review crew."""
+
+    decision: ProposalDecision = Field(
+        description="Final recommendation: accept, counter, or reject"
+    )
+    rationale: str = Field(description="Brief explanation of why this decision was reached")
+    counter_price_cpm: Optional[float] = Field(
+        default=None, description="Counter-offer CPM, only if decision is counter"
+    )
+    counter_terms: Optional[str] = Field(
+        default=None, description="Full counter-terms detail, only if decision is counter"
+    )
+    rejection_reason: Optional[str] = Field(
+        default=None, description="Reason and alternatives, only if decision is reject"
+    )
+    audience_summary: str = Field(description="Audience validation summary")
+    upsell_opportunities: list[str] = Field(
+        default_factory=list, description="Prioritized upsell opportunities"
+    )
+
+
 class PricingDecision(BaseModel):
     """Pricing decision for a deal."""
 


### PR DESCRIPTION
Fix mislabeled proposal recommendations via structured crew output

**Problem**: POST /proposals runs an AI crew to negotiate a proposal and returns its decision (accept/counter/reject) in the recommendation field. The code read this by scanning the AI's full text response for the word "accept" — but negotiation write-ups routinely contain that word elsewhere (*"not acceptable as submitted"*, "Decision (Accept/Counter/Reject)"), so a real Counter decision was often reported as accept. Confirmed in 6 of 16 test cases, always in that direction — never the reverse.

**Fix**: the crew's final task now returns a typed, structured decision (via CrewAI's output_pydantic) instead of free text to scan. recommendation is read directly from that field, so there's nothing left to misparse. Also fixed a related bug in the same function — a blocking crew call from async code, which crashed silently and masked the AI's real decision behind a rule-based guess.

**Verified**: re-ran the previously-mislabeled case — now correctly reports counter instead of accept. No change to the response shape; recommendation still returns the same three values, just reliably now.