### PR TITLE
Add custom OpenAI-compatible endpoint alternative (NVIDIA NIM, Ollama, HuggingFace, etc.)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,30 @@ LLM_MAX_TOKENS=4096
 # DEFAULT_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
 # MANAGER_LLM_MODEL=bedrock/us.anthropic.claude-opus-4-20250514-v1:0
 
+# Provider: Custom OpenAI-compatible endpoint (alternative)
+# For endpoints with no CrewAI native provider prefix of their own — NVIDIA
+# NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, etc. Set DEFAULT_LLM_MODEL to
+# the raw model id the endpoint expects, plus LLM_API_BASE_URL. LLM_API_KEY is
+# optional — omit it for endpoints (e.g. a local Ollama server) that don't
+# require one.
+#
+# NVIDIA NIM:
+# LLM_API_KEY=nvapi-your-nvidia-api-key
+# LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+# DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
+# MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
+#
+# Ollama (local or self-hosted):
+# LLM_API_BASE_URL=http://localhost:11434/v1
+# DEFAULT_LLM_MODEL=llama3
+# MANAGER_LLM_MODEL=llama3
+#
+# HuggingFace TGI (self-hosted):
+# LLM_API_KEY=hf_your-huggingface-token
+# LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
+# DEFAULT_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
+# MANAGER_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
+
 # =============================================================================
 # CrewAI Configuration
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -180,24 +180,25 @@ LLM_MAX_TOKENS=4096
 # Provider: Custom OpenAI-compatible endpoint (alternative)
 # For endpoints with no CrewAI native provider prefix of their own — NVIDIA
 # NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, etc. Set DEFAULT_LLM_MODEL to
-# the raw model id the endpoint expects, plus LLM_API_BASE_URL. LLM_API_KEY is
+# the raw model id the endpoint expects, plus
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL. OPENAI_COMPATIBLE_LLM_API_KEY is
 # optional — omit it for endpoints (e.g. a local Ollama server) that don't
 # require one.
 #
 # NVIDIA NIM:
-# LLM_API_KEY=nvapi-your-nvidia-api-key
-# LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+# OPENAI_COMPATIBLE_LLM_API_KEY=nvapi-your-nvidia-api-key
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
 # DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
 # MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 #
 # Ollama (local or self-hosted):
-# LLM_API_BASE_URL=http://localhost:11434/v1
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=http://localhost:11434/v1
 # DEFAULT_LLM_MODEL=llama3
 # MANAGER_LLM_MODEL=llama3
 #
 # HuggingFace TGI (self-hosted):
-# LLM_API_KEY=hf_your-huggingface-token
-# LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
+# OPENAI_COMPATIBLE_LLM_API_KEY=hf_your-huggingface-token
+# OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://your-tgi-endpoint.example.com/v1
 # DEFAULT_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
 # MANAGER_LLM_MODEL=meta-llama/Meta-Llama-3-8B-Instruct
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -89,8 +89,8 @@ ad-seller freewheel-login --provider bc
 | `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
-| `LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
-| `LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
+| `OPENAI_COMPATIBLE_LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
+| `OPENAI_COMPATIBLE_LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
 
 ### Supported Providers
 
@@ -122,17 +122,17 @@ For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/
 
 For endpoints that don't have one of the native provider prefixes above —
 NVIDIA NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, and similar — set
-`LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
+`OPENAI_COMPATIBLE_LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
 client regardless of the model id's shape, so `DEFAULT_LLM_MODEL` /
 `MANAGER_LLM_MODEL` should be set to the raw model id the endpoint expects
-(no provider prefix). `LLM_API_KEY` is optional — omit it for endpoints, such
+(no provider prefix). `OPENAI_COMPATIBLE_LLM_API_KEY` is optional — omit it for endpoints, such
 as a local Ollama server, that don't require one.
 
 **Example — NVIDIA NIM:**
 
 ```bash
-LLM_API_KEY=nvapi-xxxxx
-LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+OPENAI_COMPATIBLE_LLM_API_KEY=nvapi-xxxxx
+OPENAI_COMPATIBLE_LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
 DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
 MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 ```
@@ -140,7 +140,7 @@ MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
 **Example — Ollama, local or self-hosted:**
 
 ```bash
-LLM_API_BASE_URL=http://localhost:11434/v1
+OPENAI_COMPATIBLE_LLM_API_BASE_URL=http://localhost:11434/v1
 DEFAULT_LLM_MODEL=llama3
 MANAGER_LLM_MODEL=llama3
 ```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -89,6 +89,8 @@ ad-seller freewheel-login --provider bc
 | `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
+| `LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
+| `LLM_API_BASE_URL` | `str` | `None` | Base URL for a custom OpenAI-compatible endpoint; when set, `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` are sent as-is to that endpoint instead of being routed by provider prefix |
 
 ### Supported Providers
 
@@ -115,6 +117,33 @@ OPENAI_API_KEY=sk-xxxxx
     Agent prompts are tuned and tested with Claude models. Other providers work but may produce different quality results. If you switch providers, test negotiation and pricing flows to verify acceptable output quality.
 
 For other providers, see the [CrewAI LLM documentation](https://docs.crewai.com/en/learn/litellm-removal-guide).
+
+### Custom OpenAI-Compatible Endpoints
+
+For endpoints that don't have one of the native provider prefixes above —
+NVIDIA NIM, Ollama, HuggingFace TGI, vLLM, LM Studio, and similar — set
+`LLM_API_BASE_URL`. This pins the request to CrewAI's native OpenAI-compatible
+client regardless of the model id's shape, so `DEFAULT_LLM_MODEL` /
+`MANAGER_LLM_MODEL` should be set to the raw model id the endpoint expects
+(no provider prefix). `LLM_API_KEY` is optional — omit it for endpoints, such
+as a local Ollama server, that don't require one.
+
+**Example — NVIDIA NIM:**
+
+```bash
+LLM_API_KEY=nvapi-xxxxx
+LLM_API_BASE_URL=https://integrate.api.nvidia.com/v1
+DEFAULT_LLM_MODEL=meta/llama-3.1-70b-instruct
+MANAGER_LLM_MODEL=meta/llama-3.1-70b-instruct
+```
+
+**Example — Ollama, local or self-hosted:**
+
+```bash
+LLM_API_BASE_URL=http://localhost:11434/v1
+DEFAULT_LLM_MODEL=llama3
+MANAGER_LLM_MODEL=llama3
+```
 
 ## Database & Storage
 

--- a/src/ad_seller/agents/level1/inventory_manager.py
+++ b/src/ad_seller/agents/level1/inventory_manager.py
@@ -8,9 +8,10 @@ It manages overall inventory strategy with a yield optimization objective
 function, evaluates proposals, and coordinates specialist agents.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_inventory_manager() -> Agent:
@@ -28,7 +29,7 @@ def create_inventory_manager() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.manager_llm_model,
         temperature=0.3,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/ctv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/ctv_inventory_agent.py
@@ -7,9 +7,10 @@ Manages Connected TV and streaming advertising inventory including
 OTT apps, FAST channels, and household-targeted inventory.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_ctv_inventory_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_ctv_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/display_inventory_agent.py
+++ b/src/ad_seller/agents/level2/display_inventory_agent.py
@@ -7,9 +7,10 @@ Manages display advertising inventory including banners, rich media,
 and premium homepage takeovers.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_display_inventory_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_display_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
+++ b/src/ad_seller/agents/level2/linear_tv_inventory_agent.py
@@ -19,9 +19,10 @@ Two-mode operation:
   integration lands)
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_linear_tv_inventory_agent() -> Agent:
@@ -41,7 +42,7 @@ def create_linear_tv_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
+++ b/src/ad_seller/agents/level2/mobile_app_inventory_agent.py
@@ -7,9 +7,10 @@ Manages mobile application advertising inventory including iOS/Android
 SDK inventory, rewarded video, interstitials, and in-app bidding.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_mobile_app_inventory_agent() -> Agent:
@@ -29,7 +30,7 @@ def create_mobile_app_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/native_inventory_agent.py
+++ b/src/ad_seller/agents/level2/native_inventory_agent.py
@@ -7,9 +7,10 @@ Manages native advertising inventory including in-feed placements,
 content recommendations, and sponsored content.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_native_inventory_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_native_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level2/video_inventory_agent.py
+++ b/src/ad_seller/agents/level2/video_inventory_agent.py
@@ -7,9 +7,10 @@ Manages web video advertising inventory including pre-roll, mid-roll,
 and outstream formats.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_video_inventory_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_video_inventory_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.5,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/audience_validator_agent.py
+++ b/src/ad_seller/agents/level3/audience_validator_agent.py
@@ -9,9 +9,10 @@ UCP (User Context Protocol) for real-time audience matching.
 
 from typing import Any
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_audience_validator_agent(
@@ -41,7 +42,7 @@ def create_audience_validator_agent(
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for accurate validation
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/availability_agent.py
+++ b/src/ad_seller/agents/level3/availability_agent.py
@@ -7,9 +7,10 @@ Manages inventory forecasting, availability checking, and pacing
 across all inventory types.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_availability_agent() -> Agent:
@@ -26,7 +27,7 @@ def create_availability_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for accurate forecasting
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/pricing_agent.py
+++ b/src/ad_seller/agents/level3/pricing_agent.py
@@ -7,9 +7,10 @@ Manages rate cards, dynamic pricing, floor prices, and tiered
 pricing based on buyer identity.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_pricing_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_pricing_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.2,  # Low temperature for consistent pricing decisions
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/proposal_review_agent.py
+++ b/src/ad_seller/agents/level3/proposal_review_agent.py
@@ -7,9 +7,10 @@ Evaluates incoming proposals, validates against products,
 and recommends accept/counter/reject decisions.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_proposal_review_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_proposal_review_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.3,
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/agents/level3/upsell_agent.py
+++ b/src/ad_seller/agents/level3/upsell_agent.py
@@ -7,9 +7,10 @@ Identifies opportunities to expand deals, cross-sell inventory,
 and propose alternatives when rejecting proposals.
 """
 
-from crewai import LLM, Agent
+from crewai import Agent
 
 from ...config import get_settings
+from ...llm import build_llm
 
 
 def create_upsell_agent() -> Agent:
@@ -27,7 +28,7 @@ def create_upsell_agent() -> Agent:
     """
     settings = get_settings()
 
-    llm = LLM(
+    llm = build_llm(
         model=settings.default_llm_model,
         temperature=0.6,  # Higher temperature for creative suggestions
         max_tokens=settings.llm_max_tokens,

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -48,6 +48,15 @@ class Settings(BaseSettings):
     llm_temperature: float = 0.3
     llm_max_tokens: int = 4096
 
+    # Alternative: any OpenAI-wire-compatible endpoint (NVIDIA NIM, Ollama,
+    # HuggingFace TGI, vLLM, ...). Set LLM_API_BASE_URL alongside
+    # DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id the
+    # endpoint expects) to route through that endpoint instead of a named
+    # provider above. LLM_API_KEY is optional — omit it for endpoints like a
+    # local Ollama server that don't require one.
+    llm_api_key: Optional[str] = None
+    llm_api_base_url: Optional[str] = None
+
     # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_seller.db"
     redis_url: Optional[str] = None

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -49,13 +49,13 @@ class Settings(BaseSettings):
     llm_max_tokens: int = 4096
 
     # Alternative: any OpenAI-wire-compatible endpoint (NVIDIA NIM, Ollama,
-    # HuggingFace TGI, vLLM, ...). Set LLM_API_BASE_URL alongside
-    # DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id the
-    # endpoint expects) to route through that endpoint instead of a named
-    # provider above. LLM_API_KEY is optional — omit it for endpoints like a
-    # local Ollama server that don't require one.
-    llm_api_key: Optional[str] = None
-    llm_api_base_url: Optional[str] = None
+    # HuggingFace TGI, vLLM, ...). Set OPENAI_COMPATIBLE_LLM_API_BASE_URL
+    # alongside DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL (using the raw model id
+    # the endpoint expects) to route through that endpoint instead of a named
+    # provider above. OPENAI_COMPATIBLE_LLM_API_KEY is optional — omit it for
+    # endpoints like a local Ollama server that don't require one.
+    openai_compatible_llm_api_key: Optional[str] = None
+    openai_compatible_llm_api_base_url: Optional[str] = None
 
     # Database / Storage Configuration
     database_url: str = "sqlite:///./ad_seller.db"

--- a/src/ad_seller/llm/__init__.py
+++ b/src/ad_seller/llm/__init__.py
@@ -1,0 +1,43 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""LLM construction shared by all agents.
+
+The named providers (Anthropic, OpenAI, Gemini, Bedrock) are switched by
+setting DEFAULT_LLM_MODEL / MANAGER_LLM_MODEL to a "<provider>/<model>"
+string plus that provider's API key, per docs/guides/configuration.md — no
+code here is involved in that path.
+
+This module adds one more alternative: any OpenAI-wire-compatible endpoint
+that has no CrewAI native provider prefix of its own (NVIDIA NIM, Ollama,
+HuggingFace TGI, vLLM, ...). Setting LLM_API_BASE_URL pins the request to
+CrewAI's native OpenAI-compatible client regardless of the model id's shape,
+using the raw model id the endpoint expects for DEFAULT_LLM_MODEL /
+MANAGER_LLM_MODEL. Leaving LLM_API_BASE_URL unset keeps today's behavior
+exactly as-is.
+"""
+
+from crewai import LLM
+
+from ..config import get_settings
+
+# CrewAI's native OpenAI SDK client; with a base_url it drives any endpoint
+# that speaks the OpenAI wire format (NVIDIA NIM, Ollama, HuggingFace TGI, ...).
+_OPENAI_COMPATIBLE_PROVIDER = "openai"
+
+
+def build_llm(model: str, temperature: float, max_tokens: int) -> LLM:
+    """Build an ``LLM`` for ``model``, honoring a custom base URL if configured."""
+    settings = get_settings()
+
+    if settings.llm_api_base_url:
+        return LLM(
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            api_key=settings.llm_api_key,
+            provider=_OPENAI_COMPATIBLE_PROVIDER,
+            base_url=settings.llm_api_base_url,
+        )
+
+    return LLM(model=model, temperature=temperature, max_tokens=max_tokens)

--- a/src/ad_seller/llm/__init__.py
+++ b/src/ad_seller/llm/__init__.py
@@ -10,11 +10,11 @@ code here is involved in that path.
 
 This module adds one more alternative: any OpenAI-wire-compatible endpoint
 that has no CrewAI native provider prefix of its own (NVIDIA NIM, Ollama,
-HuggingFace TGI, vLLM, ...). Setting LLM_API_BASE_URL pins the request to
-CrewAI's native OpenAI-compatible client regardless of the model id's shape,
-using the raw model id the endpoint expects for DEFAULT_LLM_MODEL /
-MANAGER_LLM_MODEL. Leaving LLM_API_BASE_URL unset keeps today's behavior
-exactly as-is.
+HuggingFace TGI, vLLM, ...). Setting OPENAI_COMPATIBLE_LLM_API_BASE_URL pins
+the request to CrewAI's native OpenAI-compatible client regardless of the
+model id's shape, using the raw model id the endpoint expects for
+DEFAULT_LLM_MODEL / MANAGER_LLM_MODEL. Leaving
+OPENAI_COMPATIBLE_LLM_API_BASE_URL unset keeps today's behavior exactly as-is.
 """
 
 from crewai import LLM
@@ -30,14 +30,14 @@ def build_llm(model: str, temperature: float, max_tokens: int) -> LLM:
     """Build an ``LLM`` for ``model``, honoring a custom base URL if configured."""
     settings = get_settings()
 
-    if settings.llm_api_base_url:
+    if settings.openai_compatible_llm_api_base_url:
         return LLM(
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
-            api_key=settings.llm_api_key,
+            api_key=settings.openai_compatible_llm_api_key,
             provider=_OPENAI_COMPATIBLE_PROVIDER,
-            base_url=settings.llm_api_base_url,
+            base_url=settings.openai_compatible_llm_api_base_url,
         )
 
     return LLM(model=model, temperature=temperature, max_tokens=max_tokens)

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -14,9 +14,10 @@ def _settings(**overrides) -> Settings:
 
 
 class TestUnchangedWhenNoBaseUrl:
-    """No LLM_API_BASE_URL configured — identical to constructing LLM directly,
-    so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL provider swapping (Anthropic,
-    OpenAI, Gemini, Bedrock) works exactly as before this module existed."""
+    """No OPENAI_COMPATIBLE_LLM_API_BASE_URL configured — identical to
+    constructing LLM directly, so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL
+    provider swapping (Anthropic, OpenAI, Gemini, Bedrock) works exactly as
+    before this module existed."""
 
     def test_anthropic_model_routes_natively(self, monkeypatch):
         monkeypatch.setattr(
@@ -52,16 +53,16 @@ class TestUnchangedWhenNoBaseUrl:
 
 
 class TestCustomOpenAICompatibleEndpoint:
-    """LLM_API_BASE_URL configured — pins routing to the native OpenAI client
-    regardless of the model id's shape, covering NVIDIA NIM, Ollama,
-    HuggingFace TGI, and similar endpoints."""
+    """OPENAI_COMPATIBLE_LLM_API_BASE_URL configured — pins routing to the
+    native OpenAI client regardless of the model id's shape, covering NVIDIA
+    NIM, Ollama, HuggingFace TGI, and similar endpoints."""
 
     def test_nvidia_nim_routes_via_openai_with_base_url(self, monkeypatch):
         monkeypatch.setattr(
             "ad_seller.llm.get_settings",
             lambda: _settings(
-                llm_api_key="nvapi-test",
-                llm_api_base_url="https://integrate.api.nvidia.com/v1",
+                openai_compatible_llm_api_key="nvapi-test",
+                openai_compatible_llm_api_base_url="https://integrate.api.nvidia.com/v1",
             ),
         )
         llm = build_llm(
@@ -75,7 +76,9 @@ class TestCustomOpenAICompatibleEndpoint:
     def test_local_ollama_needs_no_key(self, monkeypatch):
         monkeypatch.setattr(
             "ad_seller.llm.get_settings",
-            lambda: _settings(llm_api_base_url="http://localhost:11434/v1"),
+            lambda: _settings(
+                openai_compatible_llm_api_base_url="http://localhost:11434/v1"
+            ),
         )
         llm = build_llm(model="llama3", temperature=0.3, max_tokens=4096)
         assert llm.provider == "openai"

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,0 +1,83 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for the custom OpenAI-compatible endpoint alternative (build_llm)."""
+
+from ad_seller.config.settings import Settings
+from ad_seller.llm import build_llm
+
+
+def _settings(**overrides) -> Settings:
+    """Build an isolated Settings instance that ignores any local .env file."""
+    overrides.setdefault("anthropic_api_key", "sk-ant-test")
+    return Settings(_env_file=None, **overrides)
+
+
+class TestUnchangedWhenNoBaseUrl:
+    """No LLM_API_BASE_URL configured — identical to constructing LLM directly,
+    so DEFAULT_LLM_MODEL/MANAGER_LLM_MODEL provider swapping (Anthropic,
+    OpenAI, Gemini, Bedrock) works exactly as before this module existed."""
+
+    def test_anthropic_model_routes_natively(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(default_llm_model="anthropic/claude-sonnet-4-5-20250929"),
+        )
+        llm = build_llm(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            temperature=0.3,
+            max_tokens=4096,
+        )
+        assert llm.model == "claude-sonnet-4-5-20250929"
+        assert llm.provider == "anthropic"
+
+    def test_openai_model_routes_natively(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(openai_api_key="sk-openai-test"),
+        )
+        llm = build_llm(model="openai/gpt-4o", temperature=0.5, max_tokens=4096)
+        assert llm.model == "gpt-4o"
+        assert llm.provider == "openai"
+
+    def test_temperature_and_max_tokens_pass_through(self, monkeypatch):
+        monkeypatch.setattr("ad_seller.llm.get_settings", lambda: _settings())
+        llm = build_llm(
+            model="anthropic/claude-sonnet-4-5-20250929",
+            temperature=0.7,
+            max_tokens=2048,
+        )
+        assert llm.temperature == 0.7
+        assert llm.max_tokens == 2048
+
+
+class TestCustomOpenAICompatibleEndpoint:
+    """LLM_API_BASE_URL configured — pins routing to the native OpenAI client
+    regardless of the model id's shape, covering NVIDIA NIM, Ollama,
+    HuggingFace TGI, and similar endpoints."""
+
+    def test_nvidia_nim_routes_via_openai_with_base_url(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(
+                llm_api_key="nvapi-test",
+                llm_api_base_url="https://integrate.api.nvidia.com/v1",
+            ),
+        )
+        llm = build_llm(
+            model="meta/llama-3.1-70b-instruct", temperature=0.3, max_tokens=4096
+        )
+        assert llm.provider == "openai"
+        assert llm.model == "meta/llama-3.1-70b-instruct"
+        assert llm.base_url == "https://integrate.api.nvidia.com/v1"
+        assert llm.api_key == "nvapi-test"
+
+    def test_local_ollama_needs_no_key(self, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.llm.get_settings",
+            lambda: _settings(llm_api_base_url="http://localhost:11434/v1"),
+        )
+        llm = build_llm(model="llama3", temperature=0.3, max_tokens=4096)
+        assert llm.provider == "openai"
+        assert llm.model == "llama3"
+        assert llm.base_url == "http://localhost:11434/v1"


### PR DESCRIPTION
## Summary
- Adds `LLM_API_KEY` / `LLM_API_BASE_URL` as an additional alternative on top of the existing named providers (Anthropic, OpenAI, Gemini, Bedrock) already on this branch.
- When `LLM_API_BASE_URL` is set, requests are pinned to CrewAI's native OpenAI-compatible client, using the raw model id the endpoint expects for `DEFAULT_LLM_MODEL`/`MANAGER_LLM_MODEL` (covers NVIDIA NIM, Ollama, HuggingFace TGI, vLLM, etc.). `LLM_API_KEY` is optional for endpoints that don't require one (e.g. local Ollama).
- Leaving `LLM_API_BASE_URL` unset keeps existing behavior exactly as-is — verified: a bare `LLM(model=..., temperature=..., max_tokens=...)` call for an unrecognized prefix (e.g. `meta/llama-3.1-70b-instruct`) raises `ImportError` since `litellm` isn't installed, and a bare unprefixed model id (e.g. `llama3`) silently misroutes to OpenAI's real API rather than a local endpoint — so the explicit `provider="openai"` + `base_url` override is required, not optional, for this to work correctly.
- All 12 agent files now construct their LLM via a shared `build_llm()` helper (`src/ad_seller/llm/__init__.py`) instead of calling `LLM(...)` directly, so the base_url logic applies uniformly. No changes to temperatures, goals, or backstories.
- `.env.example` and `docs/guides/configuration.md` gain a 4th "Custom OpenAI-compatible endpoint" block, matching the style of the existing Anthropic/OpenAI/Gemini/Bedrock blocks.

## Test plan
- [x] `pytest tests/unit` — 760 passed, 1 skipped (pre-existing, unrelated)
- [x] `mypy src/ad_seller/llm/ src/ad_seller/agents/` — clean
- [x] `ruff check` on all touched files — clean
- [x] New tests in `tests/unit/test_llm.py` cover: unchanged behavior with no base URL (Anthropic/OpenAI native routing), NVIDIA NIM via base_url, keyless local Ollama via base_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)