### PR TITLE
Replace retired manager LLM default with claude-opus-4-8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,7 +153,7 @@ PREFERRED_DEAL_DISCOUNT_MAX=0.15
 # Provider: Anthropic (default)
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
-MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
+MANAGER_LLM_MODEL=anthropic/claude-opus-4-8
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
 
@@ -175,7 +175,7 @@ LLM_MAX_TOKENS=4096
 # AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 # AWS_REGION=us-west-2
 # DEFAULT_LLM_MODEL=bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
-# MANAGER_LLM_MODEL=bedrock/us.anthropic.claude-opus-4-20250514-v1:0
+# MANAGER_LLM_MODEL=bedrock/us.anthropic.claude-opus-4-8
 
 # Provider: Custom OpenAI-compatible endpoint (alternative)
 # For endpoints with no CrewAI native provider prefix of their own — NVIDIA

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -86,7 +86,7 @@ ad-seller freewheel-login --provider bc
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `DEFAULT_LLM_MODEL` | `str` | `"anthropic/claude-sonnet-4-5-20250929"` | Model for specialist agents (pricing, negotiation, etc.) |
-| `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-20250514"` | Model for manager/orchestrator agents |
+| `MANAGER_LLM_MODEL` | `str` | `"anthropic/claude-opus-4-8"` | Model for manager/orchestrator agents |
 | `LLM_TEMPERATURE` | `float` | `0.3` | LLM temperature (lower = more deterministic) |
 | `LLM_MAX_TOKENS` | `int` | `4096` | Maximum tokens per LLM response |
 | `OPENAI_COMPATIBLE_LLM_API_KEY` | `str` | `None` | API key for a [custom OpenAI-compatible endpoint](#custom-openai-compatible-endpoints) (optional — some endpoints don't require one) |
@@ -263,7 +263,7 @@ GAM_API_VERSION=v202505
 # LLM
 # =============================================================================
 DEFAULT_LLM_MODEL=anthropic/claude-sonnet-4-5-20250929
-MANAGER_LLM_MODEL=anthropic/claude-opus-4-20250514
+MANAGER_LLM_MODEL=anthropic/claude-opus-4-8
 LLM_TEMPERATURE=0.3
 LLM_MAX_TOKENS=4096
 

--- a/src/ad_seller/config/settings.py
+++ b/src/ad_seller/config/settings.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     #   gemini/gemini-2.5-flash                (requires GOOGLE_API_KEY)
     #   bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0 (requires AWS creds)
     default_llm_model: str = "anthropic/claude-sonnet-4-5-20250929"
-    manager_llm_model: str = "anthropic/claude-opus-4-20250514"
+    manager_llm_model: str = "anthropic/claude-opus-4-8"
     llm_temperature: float = 0.3
     llm_max_tokens: int = 4096
 


### PR DESCRIPTION
## Problem

The shipped `MANAGER_LLM_MODEL` default is `anthropic/claude-opus-4-20250514`. Anthropic retired that model on June 15, 2026 ([deprecation schedule](https://platform.claude.com/docs/en/about-claude/models/migration-guide)), so any fresh install with an Anthropic key now fails at runtime with `model_not_found` the first time a manager agent is invoked. `DEFAULT_LLM_MODEL` is unaffected (Sonnet 4.5 is still active).

## Change

Swap the default to `anthropic/claude-opus-4-8`, Anthropic's designated replacement for Opus 4. Updated everywhere the old id was pinned: `settings.py`, `.env.example`, and `docs/guides/configuration.md`.

The commented Bedrock example becomes `bedrock/us.anthropic.claude-opus-4-8`: verified against LiteLLM's model registry, which carries `us.anthropic.claude-opus-4-8` as the current US inference profile id (the `-v1:0` suffix was dropped for undated model ids).

Mirrors the same fix submitted to buyer-agent, keeping the two repos' LLM defaults in sync.

## Verification

- `Settings(anthropic_api_key=...)` instantiates with the new default; no occurrence of the retired id remains in the repo.
- Note: the full suite cannot run on a public clone because `pyproject.toml` pins the private `iab-agentic-primitives` repo (same reason CI on main has been failing since ~July 20); unrelated to this change, filing separately.