### PR TITLE
Port the surgical toolResult stripping from buyer-agent

### DIFF
--- a/patches/crewai_bedrock_fix.py
+++ b/patches/crewai_bedrock_fix.py
@@ -90,7 +90,8 @@ def _sanitize_tool_blocks(messages: list) -> list:
     - If not matched, strips the toolUse blocks (keeps text blocks)
     - For each user message with toolResult blocks, checks if the previous
       assistant message has matching toolUse blocks
-    - If not matched, strips the toolResult blocks (keeps text blocks)
+    - If not matched, strips only the unmatched toolResult blocks (keeps
+      text blocks and toolResult blocks whose toolUseId does match)
 
     This handles both directions of orphaning:
     - Executor added toolUse but result is in a different message format
@@ -171,7 +172,7 @@ def _sanitize_tool_blocks(messages: list) -> list:
             if result_ids:
                 # Check if previous message (in fixed list) has matching toolUse
                 prev_msg = fixed[-1] if fixed else None
-                matched = False
+                use_ids = set()
 
                 if (
                     prev_msg
@@ -180,22 +181,25 @@ def _sanitize_tool_blocks(messages: list) -> list:
                 ):
                     prev_content = prev_msg.get("content", [])
                     if isinstance(prev_content, list):
-                        use_ids = set()
                         for block in prev_content:
                             if isinstance(block, dict) and "toolUse" in block:
                                 tu = block["toolUse"]
                                 if isinstance(tu, dict) and "toolUseId" in tu:
                                     use_ids.add(tu["toolUseId"])
-                        matched = result_ids.issubset(use_ids)
 
-                if not matched:
-                    # Strip toolResult blocks, keep text blocks
-                    text_blocks = [
+                if not result_ids.issubset(use_ids):
+                    # Only strip toolResult blocks whose toolUseId is NOT in use_ids
+                    kept_blocks = [
                         b for b in content
-                        if isinstance(b, dict) and "text" in b
+                        if not (
+                            isinstance(b, dict)
+                            and "toolResult" in b
+                            and isinstance(b["toolResult"], dict)
+                            and b["toolResult"].get("toolUseId") not in use_ids
+                        )
                     ]
-                    if text_blocks:
-                        fixed.append({"role": "user", "content": text_blocks})
+                    if kept_blocks:
+                        fixed.append({"role": "user", "content": kept_blocks})
                     i += 1
                     continue
 
@@ -203,7 +207,6 @@ def _sanitize_tool_blocks(messages: list) -> list:
         i += 1
 
     return fixed
-
 
 
 def _patch_parse_native_tool_call():


### PR DESCRIPTION
## Problem

`patches/crewai_bedrock_fix.py` has drifted between buyer-agent and seller-agent, and each repo is missing the other's fix. The one seller-agent lacks: buyer's surgical toolResult stripping. When a user message carries toolResult blocks and at least one has no matching toolUse in the preceding assistant message, the seller copy strips ALL toolResult blocks and keeps only text. Valid tool results are discarded along with the orphans, so the model loses tool output it legitimately produced.

## Change

Ports buyer-agent's surgical version: only toolResult blocks whose `toolUseId` is absent from the preceding assistant message's toolUse set are stripped; matched toolResults and text blocks are kept. The file is now byte-identical with the buyer-agent copy, at the union of both repos' fixes; a matching PR to buyer-agent ports seller's `_patch_parse_native_tool_call` in the other direction, so the two copies stay in sync. One docstring bullet updated to match the behavior.

## Verification

Ran against installed crewai: patches apply cleanly, and for a user message carrying one matched and one orphaned toolResult, the sanitizer now keeps the matched block and the text block while stripping only the orphan (previously both toolResults were dropped).