### PR TITLE
Derive default-catalog product ids deterministically (issue #34)

### DIFF
--- a/src/ad_seller/services/catalog_service.py
+++ b/src/ad_seller/services/catalog_service.py
@@ -392,11 +392,15 @@ def build_static_product_catalog() -> dict[str, Any]:
     """Build a fresh catalog dict from ``DEFAULT_PRODUCT_CONFIGS`` (uncached).
 
     Returns ``{"products": {product_id: ProductDefinition}, "inventory_types": [...]}``
-    with newly generated product IDs.
+    with deterministic product IDs derived from each config's name, so every
+    process (and every uvicorn worker) serves the same ids. Random per-process
+    ids meant a list-then-get across two workers, or across a restart, could
+    404 on an id the server itself had just returned (issue #34).
     """
     products: dict[str, Any] = {}
     for cfg in DEFAULT_PRODUCT_CONFIGS:
-        product_def = product_from_config(cfg, f"prod-{uuid.uuid4().hex[:8]}")
+        stable = uuid.uuid5(uuid.NAMESPACE_URL, f"ad-seller-product:{cfg['name']}")
+        product_def = product_from_config(cfg, f"prod-{stable.hex[:8]}")
         products[product_def.product_id] = product_def
 
     inventory_types = sorted({p.inventory_type for p in products.values()})

--- a/tests/unit/test_csv_catalog_coherence.py
+++ b/tests/unit/test_csv_catalog_coherence.py
@@ -215,6 +215,16 @@ class TestNonCsvModesUnchanged:
         second = catalog_service.get_static_product_catalog()
         assert list(first["products"].keys()) == list(second["products"].keys())
 
+    def test_default_mode_ids_survive_cache_reset(self, default_mode):
+        # Proxy for multi-worker and restart behavior (issue #34): each uvicorn
+        # worker builds its own catalog cache, so ids must be deterministic
+        # across independent builds, not merely stable within one cache.
+        first = catalog_service.get_static_product_catalog()
+        catalog_service.reset_catalog_cache()
+        second = catalog_service.get_static_product_catalog()
+        assert list(first["products"].keys()) == list(second["products"].keys())
+        assert len(set(first["products"])) == len(catalog_service.DEFAULT_PRODUCT_CONFIGS)
+
 
 # =============================================================================
 # API surface — CSV mode

--- a/tests/unit/test_service_layer.py
+++ b/tests/unit/test_service_layer.py
@@ -140,14 +140,20 @@ class TestCatalogService:
         }
         catalog_service.reset_catalog_cache()
 
-    def test_reset_generates_fresh_product_ids(self):
-        """Edge: resetting the cache regenerates product ids."""
+    def test_reset_preserves_stable_product_ids(self):
+        """Ids are deterministic: a cache reset must NOT mint new ids.
+
+        Contract change with the deterministic-id fix (issue #34): ids derive
+        from each product's name, so they are identical across resets and
+        across processes. The old fresh-ids-per-reset behavior is exactly what
+        broke follow-up lookups for external integrators.
+        """
         catalog_service.reset_catalog_cache()
         ids_before = set(catalog_service.get_static_product_catalog()["products"])
         catalog_service.reset_catalog_cache()
         ids_after = set(catalog_service.get_static_product_catalog()["products"])
 
-        assert ids_before.isdisjoint(ids_after)
+        assert ids_before == ids_after
         catalog_service.reset_catalog_cache()
 
     def test_flow_consumes_the_same_default_product_data(self):


### PR DESCRIPTION
## Problem

The last live piece of #34 observation 1. In default (non-CSV) mode, `build_static_product_catalog` mints `prod-{uuid4().hex[:8]}` ids at build time, and the catalog cache is per process. Any deployment with more than one process reproduces the reported symptom: `GET /products` served by worker A returns ids that `GET /products/{id}` on worker B has never seen, so the lookup 404s. The repo's own image runs `uvicorn --workers 2` (`infra/docker/Dockerfile:82`), and a restart between list and get does the same thing. The CSV-mode side of this was already fixed in v2.2.2 by reading ids from the CSV.

## Change

Derive each id with `uuid5(NAMESPACE_URL, "ad-seller-product:{name}")` instead of `uuid4`. Ids keep the exact `prod-[0-9a-f]{8}` shape pinned by `test_default_mode_ids_stay_uuid_shaped_and_stable`, stay unique per product, and are now identical in every process and across restarts.

Adds `test_default_mode_ids_survive_cache_reset`: rebuilds the catalog after `reset_catalog_cache()` (the single-process proxy for a second worker) and asserts the id set is unchanged, plus uniqueness across the 13 configs.

## Verification

Ran the catalog build in two separate Python processes: identical id sets, all shape-conformant, 13 unique ids. The new test passes; note the full suite needs the `iab-agentic-primitives` dependency, which public clones cannot currently install.