### PR TITLE
docs: document the quote-then-propose sequence for pricing_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ INDEX_EXCHANGE_API_URL=https://api.indexexchange.com
 | Deals | 1 | Deal creation from accepted proposals |
 | Deal Performance | 1 | Delivery metrics |
 | Bulk Operations | 1 | Batch deal create/update/cancel |
-| Proposals | 1 | Proposal submission |
+| Proposals | 1 | Proposal submission (quote-anchored price verification) |
 | Negotiation | 3 | Counter-offers + negotiation state and messages |
 | Discovery | 1 | Natural-language inventory discovery |
 | Audience | 1 | Agentic audience matching |

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -34,6 +34,11 @@ The Ad Seller System API exposes **87 endpoints** across **25 tags**. All endpoi
 |--------|------|---------|
 | POST | `/proposals` | Submit a proposal for review |
 
+`pricing_verified` on the response is quote-anchored: it requires a quote
+previously issued for the same buyer and product. Proposing without a prior
+quote returns `pricing_verified: false` by design. See
+[Price Verification](../guides/pricing-rules.md#price-verification-quote-anchored).
+
 ## Deals
 
 | Method | Path | Summary |

--- a/docs/guides/pricing-rules.md
+++ b/docs/guides/pricing-rules.md
@@ -186,6 +186,47 @@ Each tier maps to a negotiation strategy with specific concession limits:
 
 ---
 
+## Price Verification (Quote-Anchored)
+
+Proposal responses carry a `pricing_verified` boolean and a
+`pricing_verification_reason` string. Verification is **quote-anchored**: the
+proposed CPM is compared against the active quotes this seller has issued for
+the same buyer identity and product, and must fall within tolerance of one of
+them. There is deliberately no rate-card or floor fallback -- an unanchored
+"verified" would defeat the purpose of the field.
+
+The field is a trust guard against price hallucination. An agent can claim any
+price in a proposal; `pricing_verified` answers a narrower and more useful
+question -- does this price match something the seller actually offered?
+
+### Sequence matters
+
+```
+1. POST /api/v1/quotes    -> quote_id, quoted CPM
+2. POST /proposals        -> propose the same product at the quoted price
+                             pricing_verified: true
+```
+
+Proposing first is the intuitive order but cannot verify:
+
+```
+POST /proposals (no prior quote)
+  pricing_verified: false
+  pricing_verification_reason: "No matching quote found for this buyer and product."
+```
+
+That response is correct behavior, not a fault. If you see `false` on every
+proposal, check whether a quote was issued for that buyer and product first.
+
+### What each outcome means
+
+| `pricing_verified` | Meaning |
+|---|---|
+| `true` | Proposed CPM falls within tolerance of a quote this seller issued. The reason names the quote ID and the difference, e.g. `Proposed CPM $15.00 matches quote qt-367309d94d20 ($15.00, 0.0% difference).` |
+| `false` | Either no quote exists for this buyer and product, or the proposed CPM is outside tolerance of every active quote. `pricing_verification_reason` distinguishes them: `No matching quote found for this buyer and product.` versus `Proposed CPM $18.00 is outside tolerance of all active quotes for this buyer and product.` |
+
+---
+
 ## Cross-Advertiser Pricing Consistency
 
 The seller agent enforces consistent pricing for the same advertiser regardless


### PR DESCRIPTION
Documents the quote-then-propose sequence for `pricing_verified`, as invited on #41.

Per the confirmation there: verification is quote-anchored by design, with no rate-card or floor fallback, because an unanchored "verified" would defeat the purpose of the field. Before this change `pricing_verified` appeared only in  `docs/api/openapi.json`, so an operator following the intuitive order (propose first, without a prior matching quote) receives `false` and could reasonably conclude verification is broken.

**Changes**

- `docs/guides/pricing-rules.md` -- new **Price Verification (Quote-Anchored)** section covering the mechanism, required sequence, and outcomes. Placed after the negotiation material and before cross-advertiser consistency, both price-integrity topics.
- `docs/api/overview.md` -- cross-reference under **Proposals**, where the field appears on the response.
- `README.md` -- clarifying phrase on the Proposals endpoint-table row.

**Verified against** seller-agent `v2.4.1`, all three paths:

- No prior quote -> `false`, "No matching quote found for this buyer and product."
- Quote at $15.00, propose at $15.00 -> `true`, "Proposed CPM $15.00 matches quote qt-367309d94d20 ($15.00, 0.0% difference)."
- Quote at $15.00, propose at $18.00 -> `false`, "Proposed CPM $18.00 is outside tolerance of all active quotes for this buyer and product."

Docs only -- no code or test changes. Happy to adjust placement or wording, and to add cross-references elsewhere if useful.