### PR TITLE
fix: chat-mode router misses 'list products' and 'create a deal'

### DIFF
--- a/src/ad_seller/interfaces/chat/main.py
+++ b/src/ad_seller/interfaces/chat/main.py
@@ -356,7 +356,14 @@ class ChatInterface:
 
     def _is_deal_request(self, message: str) -> bool:
         """Check if message is a deal creation request."""
-        deal_keywords = ["create deal", "book", "buy inventory", "want to buy", "make a deal"]
+        deal_keywords = [
+            "create a deal",
+            "create deal",
+            "book",
+            "buy inventory",
+            "want to buy",
+            "make a deal",
+        ]
         return any(keyword in message for keyword in deal_keywords)
 
     def _is_pricing_inquiry(self, message: str) -> bool:
@@ -382,7 +389,7 @@ class ChatInterface:
 
     def _is_availability_inquiry(self, message: str) -> bool:
         """Check if message is an availability inquiry."""
-        avail_keywords = ["available", "inventory", "impressions", "capacity"]
+        avail_keywords = ["available", "inventory", "impressions", "capacity", "product", "catalog"]
         return any(keyword in message for keyword in avail_keywords)
 
     def _handle_deal_request(

--- a/tests/integration/agentcore/test_runtime.py
+++ b/tests/integration/agentcore/test_runtime.py
@@ -183,10 +183,13 @@ class TestChatMode:
     """Tests for the chat routing mode (keyword-based ChatInterface)."""
 
     def test_list_products(self, runtime_config):
-        """Chat mode responds to 'list products' with inventory data."""
+        """Chat mode routes 'list products' to availability, not the general fallback."""
         result = invoke_runtime(runtime_config, {"prompt": "list products"})
         assert result["success"], f"Invoke failed: {result['error']}"
-        # Should mention products or inventory
+        raw = result["raw"].lower()
+        assert '"type": "general"' not in raw, (
+            f"'list products' fell through to general handler: {result['response'][:200]}"
+        )
         response = result["response"].lower()
         assert any(kw in response for kw in ["product", "inventory", "ctv", "video", "display"]), (
             f"Response doesn't mention products: {result['response'][:200]}"

--- a/tests/unit/test_chat_routing.py
+++ b/tests/unit/test_chat_routing.py
@@ -1,0 +1,57 @@
+"""Tests for ChatInterface keyword routing.
+
+Verifies that documented and advertised prompts reach the correct intent
+handler rather than falling through to the general fallback.
+"""
+
+import pytest
+
+from ad_seller.interfaces.chat.main import ChatInterface
+
+
+@pytest.fixture
+def chat():
+    return ChatInterface()
+
+
+class TestChatIntentRouting:
+    """Each prompt should map to the expected intent type."""
+
+    @pytest.mark.parametrize(
+        "prompt, expected_type",
+        [
+            ("list products", "availability"),
+            ("show me your product catalog", "availability"),
+            ("what CTV inventory do you have?", "availability"),
+            ("available impressions for display", "availability"),
+            ("how much does video inventory cost?", "pricing"),
+            ("what is the CPM for CTV?", "pricing"),
+            ("create deal for 5M impressions", "deal"),
+            ("I want to create a deal for 5M display impressions", "deal"),
+            ("book a campaign for next quarter", "deal"),
+            ("make a deal for sports inventory", "deal"),
+            ("that's too expensive, can you do $30?", "negotiation"),
+            ("how about $25 CPM instead?", "negotiation"),
+        ],
+    )
+    def test_prompt_routes_to_expected_intent(self, chat, prompt, expected_type):
+        result = chat.process_message(prompt)
+        assert result["type"] == expected_type, (
+            f"'{prompt}' routed to '{result['type']}', expected '{expected_type}'"
+        )
+
+    def test_general_handler_example_prompts_do_not_self_refer(self, chat):
+        """Example prompts printed by the general handler should not route to general."""
+        general_response = chat.process_message("hello")
+        assert general_response["type"] == "general"
+
+        example_lines = [
+            line.strip().lstrip("- ").strip('"')
+            for line in general_response["text"].splitlines()
+            if line.strip().startswith("- ")
+        ]
+        for example in example_lines:
+            result = chat.process_message(example)
+            assert result["type"] != "general", (
+                f"General handler's own example '{example}' routes back to general"
+            )


### PR DESCRIPTION
## Summary

The chat-mode keyword router in `ChatInterface.process_message` falls through to the general handler for two prompts that the repository itself ships as documented examples:

- **`list products`** — the default AgentCore smoke-test prompt, the documented chat-mode example, and the input to `TestChatMode::test_list_products` — matches no intent because `product` is absent from the availability keyword set.
- **`I want to create a deal for 5M display impressions`** — the third example printed by the general handler itself — misses the deal matcher because `create deal` doesn't match `create a deal` (the article is missing from the keyword list). It instead hits the availability matcher on `impressions`.

Neither the integration test nor the deployment smoke check caught this: the integration assertion was satisfied by the general fallback's text (which contains all five asserted keywords), and the smoke check only looks for error markers.

## Changes

**Router keywords** (`src/ad_seller/interfaces/chat/main.py`):
- Add `product` and `catalog` to `_is_availability_inquiry` so `list products` routes to availability
- Add `create a deal` to `_is_deal_request` (before `create deal` so the longer match is tested first) so the general handler's own example prompt reaches the deal handler

**Integration test** (`tests/integration/agentcore/test_runtime.py`):
- `test_list_products` now asserts `"type": "general"` is absent from the raw response, catching routing fallthrough that the content-keyword assertion alone cannot distinguish

**Unit test** (`tests/unit/test_chat_routing.py`):
- Parametric test covering all five intent types with representative prompts
- Guard test verifying the general handler's example prompts do not route back to general

## Test plan

- [x] `pytest tests/unit/test_chat_routing.py -v` — 13 tests pass
- [x] Full unit suite (`pytest tests/unit/`) — 1393 tests pass, no regressions
- [x] `ruff check` and `ruff format --check` clean

Closes #46