### PR TITLE
fix: remove hardcoded US-scoped MEMORY_LLM_MODEL from deploy.sh

### DIFF
--- a/infra/aws/agentcore/deploy.sh
+++ b/infra/aws/agentcore/deploy.sh
@@ -480,7 +480,6 @@ deploy_mcp_runtime() {
     --env "ANTHROPIC_API_KEY=not-used-with-bedrock"
     --env "DATABASE_URL=sqlite:///:memory:"
     --env "CREW_MEMORY_ENABLED=true"
-    --env "MEMORY_LLM_MODEL=bedrock/us.amazon.nova-lite-v1:0"
   )
 
   if [[ "${INVENTORY_TYPE}" == "s3" ]]; then
@@ -564,7 +563,6 @@ deploy_http_runtime() {
     --env "ANTHROPIC_API_KEY=not-used-with-bedrock"
     --env "DATABASE_URL=sqlite:///:memory:"
     --env "CREW_MEMORY_ENABLED=true"
-    --env "MEMORY_LLM_MODEL=bedrock/us.amazon.nova-lite-v1:0"
   )
 
   if [[ "${INVENTORY_TYPE}" == "s3" ]]; then


### PR DESCRIPTION
## Summary

`deploy.sh` unconditionally injects `MEMORY_LLM_MODEL=bedrock/us.amazon.nova-lite-v1:0` into both the MCP and HTTP runtime configurations (lines 483 and 567). The `us.`-prefixed inference profile is not resolvable in non-US regions — verified as a `ValidationException` in `ap-southeast-2` — and there is no override path for the caller.

This is asymmetric with the surrounding configuration: `DEFAULT_LLM_MODEL` and `MANAGER_LLM_MODEL` are both parameterized via `${LLM_MODEL}`, but `MEMORY_LLM_MODEL` was hardcoded.

## Changes

Removed the two `--env "MEMORY_LLM_MODEL=..."` lines from `deploy_mcp_runtime()` and `deploy_http_runtime()`.

The memory patch (`patches/crewai_agentcore_memory.py:120-123`) already has the correct fallback chain:

```python
bedrock_model = os.environ.get(
    "MEMORY_LLM_MODEL",
    os.environ.get("DEFAULT_LLM_MODEL", "bedrock/us.amazon.nova-lite-v1:0"),
)
```

With `MEMORY_LLM_MODEL` unset, memory inherits `DEFAULT_LLM_MODEL` — which `deploy.sh` already parameterizes via `${LLM_MODEL}`. Non-US deployments receive a region-valid model without any additional change. Callers who want an explicit memory model can still set `MEMORY_LLM_MODEL` in their environment.

## Test plan

- [x] Verified no other references to `MEMORY_LLM_MODEL` in `deploy.sh` after the change
- [x] Confirmed the Python fallback chain in `crewai_agentcore_memory.py` inherits `DEFAULT_LLM_MODEL` when `MEMORY_LLM_MODEL` is unset
- [x] Full unit test suite passes (1393 tests, no regressions)

Closes #45