### PR TITLE
fix: enforce idempotency on POST /api/v1/quotes, add conflict detection

### DIFF
--- a/src/ad_seller/interfaces/api/contract_mappers.py
+++ b/src/ad_seller/interfaces/api/contract_mappers.py
@@ -16,6 +16,8 @@ dollars; the shared contract prices in :class:`Money` (integer micros).
 Conversion happens here and nowhere else.
 """
 
+import hashlib
+import json
 from datetime import date, datetime
 from typing import Any, Optional
 
@@ -109,6 +111,30 @@ def unsupported_capability_detail(
         unsupported=capabilities,
     )
     return detail.model_dump(mode="json")
+
+
+def idempotency_conflict_detail(message: str = "") -> dict[str, Any]:
+    """Build the ``{"error": "idempotency_conflict", ...}`` inner detail (FD-12).
+
+    Returned as the ``detail`` of a FastAPI ``HTTPException(status_code=409)``
+    when an ``idempotency_key`` is reused with a different request body.
+    """
+    detail = ErrorDetail(
+        error=ErrorCode.IDEMPOTENCY_CONFLICT,
+        message=message or "idempotency_key was reused with a different request body.",
+    )
+    return detail.model_dump(mode="json")
+
+
+def request_payload_hash(payload: dict[str, Any]) -> str:
+    """Stable hash of a request payload, for idempotency-key conflict detection.
+
+    Callers pass ``request.model_dump(mode="json", exclude={"idempotency_key"})``
+    so the key itself never affects its own conflict check. ``sort_keys``
+    makes the hash independent of dict/field ordering.
+    """
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/src/ad_seller/interfaces/api/contract_mappers.py
+++ b/src/ad_seller/interfaces/api/contract_mappers.py
@@ -137,6 +137,30 @@ def request_payload_hash(payload: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def idempotency_buyer_scope(identity: Any) -> str:
+    """Stable per-buyer scope string for idempotency-key namespacing (FD-12).
+
+    FD-12 scopes an ``idempotency_key`` to a buyer/seller pair — a global
+    key namespace lets two different buyers collide on the same
+    client-chosen key. Mirrors the specificity order of
+    :meth:`BuyerContext.get_pricing_key` so a request-body identity
+    (``buyer_identity`` / an API key's ``.identity``) resolves to the same
+    scope wherever it is used.
+
+    ``identity`` is any object exposing optional ``advertiser_id`` /
+    ``agency_id`` / ``seat_id`` attributes (or ``None``).
+    """
+    if identity is None:
+        return "public"
+    if getattr(identity, "advertiser_id", None):
+        return f"advertiser:{identity.advertiser_id}"
+    if getattr(identity, "agency_id", None):
+        return f"agency:{identity.agency_id}"
+    if getattr(identity, "seat_id", None):
+        return f"seat:{identity.seat_id}"
+    return "public"
+
+
 # ---------------------------------------------------------------------------
 # Quote surface
 # ---------------------------------------------------------------------------

--- a/src/ad_seller/interfaces/api/routers/deals.py
+++ b/src/ad_seller/interfaces/api/routers/deals.py
@@ -95,7 +95,10 @@ async def book_deal(
     ``idempotency_key``. A replay with a key already used for an identical
     body returns the same Deal without minting a second one (no duplicate
     side effect); the same key reused with a different body is an
-    ``idempotency_conflict`` (HTTP 409).
+    ``idempotency_conflict`` (HTTP 409). The key is scoped per buyer
+    (FD-12) — API key identity takes priority over the self-asserted
+    ``buyer_identity`` body field, matching the priority order used to
+    resolve buyer identity elsewhere.
     """
     from ....storage.factory import get_storage
 
@@ -105,7 +108,11 @@ async def book_deal(
     # response, no duplicate booking (FD-12). Kept at the wire edge so
     # deal_service stays untouched. Defensive against storage backends/
     # mocks that do not implement the generic get/set KV methods.
-    idem_storage_key = f"idempotency:deal:{request.idempotency_key}"
+    buyer_identity = (
+        api_key_record.identity if api_key_record is not None else request.buyer_identity
+    )
+    buyer_scope = cm.idempotency_buyer_scope(buyer_identity)
+    idem_storage_key = f"idempotency:deal:{buyer_scope}:{request.idempotency_key}"
     payload_hash = cm.request_payload_hash(
         request.model_dump(mode="json", exclude={"idempotency_key"})
     )
@@ -127,6 +134,14 @@ async def book_deal(
                 ),
             )
         existing = await deal_service.get_deal(prior["deal_id"])
+        return cm.internal_deal_to_response(existing)
+    elif isinstance(prior, str) and prior:
+        # Legacy pre-migration record: plain string deal_id with no stored
+        # hash (the shape this endpoint wrote before payload-hash conflict
+        # detection existed). No hash to compare against, so replay it as
+        # the original booking rather than risk a duplicate deal for a key
+        # created before this deploy.
+        existing = await deal_service.get_deal(prior)
         return cm.internal_deal_to_response(existing)
 
     result = await deal_service.book_deal(internal_request)

--- a/src/ad_seller/interfaces/api/routers/deals.py
+++ b/src/ad_seller/interfaces/api/routers/deals.py
@@ -92,34 +92,51 @@ async def book_deal(
     resolution.
 
     **Idempotency (FD-12):** the request carries a required
-    ``idempotency_key``. A replay with a key already booked returns the
-    same Deal without minting a second one (no duplicate side effect).
+    ``idempotency_key``. A replay with a key already used for an identical
+    body returns the same Deal without minting a second one (no duplicate
+    side effect); the same key reused with a different body is an
+    ``idempotency_conflict`` (HTTP 409).
     """
     from ....storage.factory import get_storage
 
     internal_request = cm.deal_booking_request_to_internal(request)
 
-    # Honor the shared idempotency key: same key -> same response, no
-    # duplicate booking (FD-12). Kept at the wire edge so deal_service
-    # stays untouched. Defensive against storage backends/mocks that do
-    # not implement the generic get/set KV methods.
+    # Honor the shared idempotency key: same key + same body -> same
+    # response, no duplicate booking (FD-12). Kept at the wire edge so
+    # deal_service stays untouched. Defensive against storage backends/
+    # mocks that do not implement the generic get/set KV methods.
     idem_storage_key = f"idempotency:deal:{request.idempotency_key}"
+    payload_hash = cm.request_payload_hash(
+        request.model_dump(mode="json", exclude={"idempotency_key"})
+    )
     storage = await get_storage()
     try:
-        prior_deal_id = await storage.get(idem_storage_key)
+        prior = await storage.get(idem_storage_key)
     except Exception:
-        prior_deal_id = None
-    # Only a real, previously-persisted string id counts as a prior booking;
+        prior = None
+    # Only a real, previously-persisted record counts as a prior booking;
     # this also guards against AsyncMock storages that auto-return truthy
     # sentinels for undefined KV methods.
-    if isinstance(prior_deal_id, str) and prior_deal_id:
-        existing = await deal_service.get_deal(prior_deal_id)
+    if isinstance(prior, dict) and prior.get("deal_id"):
+        if prior.get("payload_hash") != payload_hash:
+            raise HTTPException(
+                status_code=409,
+                detail=cm.idempotency_conflict_detail(
+                    f"idempotency_key '{request.idempotency_key}' was already used "
+                    "for a different deal booking request."
+                ),
+            )
+        existing = await deal_service.get_deal(prior["deal_id"])
         return cm.internal_deal_to_response(existing)
 
     result = await deal_service.book_deal(internal_request)
 
     try:
-        await storage.set(idem_storage_key, result["deal_id"], ttl=86400)
+        await storage.set(
+            idem_storage_key,
+            {"deal_id": result["deal_id"], "payload_hash": payload_hash},
+            ttl=86400,
+        )
     except Exception:
         pass
 

--- a/src/ad_seller/interfaces/api/routers/deals.py
+++ b/src/ad_seller/interfaces/api/routers/deals.py
@@ -121,6 +121,16 @@ async def book_deal(
         prior = await storage.get(idem_storage_key)
     except Exception:
         prior = None
+    if prior is None:
+        # Fallback for records written before buyer-scoping landed: those
+        # were stored bare at idempotency:deal:{key}, with no scope segment,
+        # so a scoped-key miss doesn't mean "no prior booking" by itself.
+        # Removable one TTL window (24h) after this deploys.
+        legacy_storage_key = f"idempotency:deal:{request.idempotency_key}"
+        try:
+            prior = await storage.get(legacy_storage_key)
+        except Exception:
+            prior = None
     # Only a real, previously-persisted record counts as a prior booking;
     # this also guards against AsyncMock storages that auto-return truthy
     # sentinels for undefined KV methods.
@@ -138,9 +148,9 @@ async def book_deal(
     elif isinstance(prior, str) and prior:
         # Legacy pre-migration record: plain string deal_id with no stored
         # hash (the shape this endpoint wrote before payload-hash conflict
-        # detection existed). No hash to compare against, so replay it as
-        # the original booking rather than risk a duplicate deal for a key
-        # created before this deploy.
+        # detection and buyer-scoping existed). No hash to compare against,
+        # so replay it as the original booking rather than risk a duplicate
+        # deal for a key created before this deploy.
         existing = await deal_service.get_deal(prior)
         return cm.internal_deal_to_response(existing)
 

--- a/src/ad_seller/interfaces/api/routers/quotes.py
+++ b/src/ad_seller/interfaces/api/routers/quotes.py
@@ -34,7 +34,35 @@ async def create_quote(
     The seller evaluates the request against existing pricing rules and
     returns a quote with pricing, terms, and availability. Quotes are
     ephemeral with a 24-hour TTL — no Deal ID is created.
+
+    **Idempotency (FD-12):** the request carries a required
+    ``idempotency_key``. A replay with a key already used for an identical
+    body returns the same Quote without minting a second one; the same key
+    reused with a different body is an ``idempotency_conflict`` (HTTP 409).
     """
+    from ....storage.factory import get_storage
+
+    idem_storage_key = f"idempotency:quote:{request.idempotency_key}"
+    payload_hash = cm.request_payload_hash(
+        request.model_dump(mode="json", exclude={"idempotency_key"})
+    )
+    storage = await get_storage()
+    try:
+        prior = await storage.get(idem_storage_key)
+    except Exception:
+        prior = None
+    if isinstance(prior, dict) and prior.get("quote_id"):
+        if prior.get("payload_hash") != payload_hash:
+            raise HTTPException(
+                status_code=409,
+                detail=cm.idempotency_conflict_detail(
+                    f"idempotency_key '{request.idempotency_key}' was already used "
+                    "for a different quote request."
+                ),
+            )
+        existing = await quote_service.get_quote(prior["quote_id"])
+        return cm.internal_quote_to_response(existing, media_type=request.media_type)
+
     # FD-6: reject unsupported media structurally instead of silently
     # dropping/mispricing (the old inline model dropped media_type entirely).
     if request.media_type not in cm.SUPPORTED_MEDIA_TYPES:
@@ -75,6 +103,16 @@ async def create_quote(
 
     internal_request = cm.quote_request_to_internal(request)
     result = await quote_service.create_quote(internal_request, context, catalog)
+
+    try:
+        await storage.set(
+            idem_storage_key,
+            {"quote_id": result["quote_id"], "payload_hash": payload_hash},
+            ttl=86400,
+        )
+    except Exception:
+        pass
+
     return cm.internal_quote_to_response(result, media_type=request.media_type)
 
 

--- a/src/ad_seller/interfaces/api/routers/quotes.py
+++ b/src/ad_seller/interfaces/api/routers/quotes.py
@@ -39,29 +39,11 @@ async def create_quote(
     ``idempotency_key``. A replay with a key already used for an identical
     body returns the same Quote without minting a second one; the same key
     reused with a different body is an ``idempotency_conflict`` (HTTP 409).
+    The key is scoped per buyer (FD-12) — buyer verification runs before
+    the replay lookup so a second buyer can never ride an unverified
+    replay of the first buyer's key.
     """
     from ....storage.factory import get_storage
-
-    idem_storage_key = f"idempotency:quote:{request.idempotency_key}"
-    payload_hash = cm.request_payload_hash(
-        request.model_dump(mode="json", exclude={"idempotency_key"})
-    )
-    storage = await get_storage()
-    try:
-        prior = await storage.get(idem_storage_key)
-    except Exception:
-        prior = None
-    if isinstance(prior, dict) and prior.get("quote_id"):
-        if prior.get("payload_hash") != payload_hash:
-            raise HTTPException(
-                status_code=409,
-                detail=cm.idempotency_conflict_detail(
-                    f"idempotency_key '{request.idempotency_key}' was already used "
-                    "for a different quote request."
-                ),
-            )
-        existing = await quote_service.get_quote(prior["quote_id"])
-        return cm.internal_quote_to_response(existing, media_type=request.media_type)
 
     # FD-6: reject unsupported media structurally instead of silently
     # dropping/mispricing (the old inline model dropped media_type entirely).
@@ -81,7 +63,10 @@ async def create_quote(
 
     # Resolve buyer identity — API key takes priority over body. EP-5.2:
     # the claimed tier is verified against the agent registry (agent_url)
-    # and capped at the verified ceiling; unverifiable claims floor.
+    # and capped at the verified ceiling; unverifiable claims floor. Run
+    # BEFORE the idempotency lookup: the verified identity scopes the
+    # idempotency key (FD-12 is per buyer/seller pair, not global), and a
+    # replay must never short-circuit past this buyer's own verification.
     buyer_ident = request.buyer_identity
     context = await deps._verified_buyer_context(
         endpoint="POST /api/v1/quotes",
@@ -100,6 +85,27 @@ async def create_quote(
         api_key_record=api_key_record,
         agent_url=request.agent_url,
     )
+
+    idem_storage_key = f"idempotency:quote:{context.get_pricing_key()}:{request.idempotency_key}"
+    payload_hash = cm.request_payload_hash(
+        request.model_dump(mode="json", exclude={"idempotency_key"})
+    )
+    storage = await get_storage()
+    try:
+        prior = await storage.get(idem_storage_key)
+    except Exception:
+        prior = None
+    if isinstance(prior, dict) and prior.get("quote_id"):
+        if prior.get("payload_hash") != payload_hash:
+            raise HTTPException(
+                status_code=409,
+                detail=cm.idempotency_conflict_detail(
+                    f"idempotency_key '{request.idempotency_key}' was already used "
+                    "for a different quote request."
+                ),
+            )
+        existing = await quote_service.get_quote(prior["quote_id"])
+        return cm.internal_quote_to_response(existing, media_type=request.media_type)
 
     internal_request = cm.quote_request_to_internal(request)
     result = await quote_service.create_quote(internal_request, context, catalog)

--- a/tests/unit/test_deal_booking_endpoints.py
+++ b/tests/unit/test_deal_booking_endpoints.py
@@ -250,6 +250,71 @@ class TestBookDeal:
         assert second.status_code == 409
         assert second.json()["detail"]["error"] == "idempotency_conflict"
 
+    async def test_idempotency_key_scoped_per_buyer(self, client, mock_storage):
+        """FD-12 scopes the idempotency namespace per buyer — a record stored
+        under one buyer's identity must not be visible to a different buyer
+        who reuses the same client-chosen key (review follow-up on #50)."""
+        from ad_seller.models.buyer_identity import BuyerIdentity
+
+        quote = _make_available_quote()
+        mock_storage._store[f"quote:{quote['quote_id']}"] = quote
+        # As if buyer A already booked a (different) deal under this key.
+        mock_storage._store["idempotency:deal:advertiser:adv-buyer-a:idem-shared"] = {
+            "deal_id": "DEMO-OTHERBUYER",
+            "payload_hash": "not-the-real-hash",
+        }
+
+        buyer_b = MagicMock(identity=BuyerIdentity(advertiser_id="adv-buyer-b"))
+        app.dependency_overrides[_get_optional_api_key_record] = lambda: buyer_b
+        try:
+            with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+                resp = await client.post(
+                    "/api/v1/deals",
+                    json={"idempotency_key": "idem-shared", "quote_id": quote["quote_id"]},
+                )
+        finally:
+            app.dependency_overrides[_get_optional_api_key_record] = lambda: None
+
+        assert resp.status_code == 200
+        assert resp.json()["deal"]["deal_id"] != "DEMO-OTHERBUYER"
+
+    async def test_legacy_string_record_replays_without_conflict(self, client, mock_storage):
+        """Pre-migration idempotency records (plain string deal_id, no hash)
+        must still replay cleanly rather than book a duplicate deal or false-
+        conflict (review follow-up on #50: a retry straddling the deploy that
+        added payload-hash conflict detection)."""
+        quote = _make_available_quote()
+        mock_storage._store[f"quote:{quote['quote_id']}"] = quote
+        mock_storage._store["deal:DEMO-LEGACY0001"] = {
+            "deal_id": "DEMO-LEGACY0001",
+            "deal_type": "PD",
+            "status": "proposed",
+            "quote_id": quote["quote_id"],
+            "product": {
+                "product_id": "ctv-premium-sports",
+                "name": "CTV",
+                "inventory_type": "ctv",
+            },
+            "pricing": {"base_cpm": 35.0, "final_cpm": 28.26, "currency": "USD"},
+            "terms": {"impressions": 5000000},
+            "expires_at": (datetime.utcnow() + timedelta(days=29)).isoformat() + "Z",
+            "created_at": datetime.utcnow().isoformat() + "Z",
+        }
+        # Pre-PR50 shape: bare string, written before conflict detection existed.
+        mock_storage._store["idempotency:deal:public:idem-legacy"] = "DEMO-LEGACY0001"
+
+        with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+            resp = await client.post(
+                "/api/v1/deals",
+                json={"idempotency_key": "idem-legacy", "quote_id": quote["quote_id"]},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["deal"]["deal_id"] == "DEMO-LEGACY0001"
+        # No duplicate deal was minted.
+        deal_keys = [k for k in mock_storage._store if k.startswith("deal:")]
+        assert deal_keys == ["deal:DEMO-LEGACY0001"]
+
 
 # =============================================================================
 # GET /api/v1/deals/{deal_id}

--- a/tests/unit/test_deal_booking_endpoints.py
+++ b/tests/unit/test_deal_booking_endpoints.py
@@ -279,10 +279,12 @@ class TestBookDeal:
         assert resp.json()["deal"]["deal_id"] != "DEMO-OTHERBUYER"
 
     async def test_legacy_string_record_replays_without_conflict(self, client, mock_storage):
-        """Pre-migration idempotency records (plain string deal_id, no hash)
-        must still replay cleanly rather than book a duplicate deal or false-
-        conflict (review follow-up on #50: a retry straddling the deploy that
-        added payload-hash conflict detection)."""
+        """Pre-migration idempotency records — bare string deal_id, unscoped
+        key, no stored hash, exactly as main writes them today — must still
+        replay cleanly via the legacy-key fallback rather than book a
+        duplicate deal (review follow-up on #50: a retry straddling the
+        deploy that added payload-hash conflict detection AND buyer
+        scoping)."""
         quote = _make_available_quote()
         mock_storage._store[f"quote:{quote['quote_id']}"] = quote
         mock_storage._store["deal:DEMO-LEGACY0001"] = {
@@ -300,8 +302,9 @@ class TestBookDeal:
             "expires_at": (datetime.utcnow() + timedelta(days=29)).isoformat() + "Z",
             "created_at": datetime.utcnow().isoformat() + "Z",
         }
-        # Pre-PR50 shape: bare string, written before conflict detection existed.
-        mock_storage._store["idempotency:deal:public:idem-legacy"] = "DEMO-LEGACY0001"
+        # True pre-PR50 shape as main actually writes it: bare, unscoped
+        # key with no scope segment (buyer-scoping didn't exist yet either).
+        mock_storage._store["idempotency:deal:idem-legacy"] = "DEMO-LEGACY0001"
 
         with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
             resp = await client.post(

--- a/tests/unit/test_deal_booking_endpoints.py
+++ b/tests/unit/test_deal_booking_endpoints.py
@@ -229,6 +229,27 @@ class TestBookDeal:
         assert second.status_code == 200
         assert first.json()["deal"]["deal_id"] == second.json()["deal"]["deal_id"]
 
+    async def test_reused_key_different_body_returns_409(self, client, mock_storage):
+        """Same idempotency_key against a different quote_id is a conflict (FD-12, issue #44)."""
+        quote_a = _make_available_quote(quote_id="qt-first111111")
+        quote_b = _make_available_quote(quote_id="qt-second222222")
+        mock_storage._store[f"quote:{quote_a['quote_id']}"] = quote_a
+        mock_storage._store[f"quote:{quote_b['quote_id']}"] = quote_b
+
+        with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+            first = await client.post(
+                "/api/v1/deals",
+                json={"idempotency_key": "idem-conflict", "quote_id": quote_a["quote_id"]},
+            )
+            second = await client.post(
+                "/api/v1/deals",
+                json={"idempotency_key": "idem-conflict", "quote_id": quote_b["quote_id"]},
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 409
+        assert second.json()["detail"]["error"] == "idempotency_conflict"
+
 
 # =============================================================================
 # GET /api/v1/deals/{deal_id}

--- a/tests/unit/test_quote_endpoints.py
+++ b/tests/unit/test_quote_endpoints.py
@@ -508,6 +508,40 @@ class TestQuoteIdempotency:
         assert second.status_code == 200
         assert first.json()["quote"]["quote_id"] != second.json()["quote"]["quote_id"]
 
+    async def test_idempotency_key_scoped_per_buyer(self, client, mock_storage):
+        """FD-12 scopes the idempotency namespace per buyer — a record stored
+        under one buyer's identity must not be visible to a different buyer
+        who reuses the same client-chosen key (review follow-up on #50).
+        Buyer verification must also run before the replay lookup, so a
+        different buyer's request is never short-circuited past its own
+        pricing-tier check."""
+        # As if buyer A already used this key for a different quote.
+        mock_storage._store["idempotency:quote:advertiser:adv-buyer-a:idem-shared"] = {
+            "quote_id": "qt-otherbuyer1",
+            "payload_hash": "not-the-real-hash",
+        }
+
+        with (
+            patch(
+                "ad_seller.interfaces.api.main._get_static_product_catalog",
+                return_value=_mock_catalog(_products()),
+            ),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            resp = await client.post(
+                "/api/v1/quotes",
+                json=_body(
+                    idempotency_key="idem-shared",
+                    product_id="ctv-premium-sports",
+                    deal_type="PD",
+                    impressions=1000000,
+                    buyer_identity={"advertiser_id": "adv-buyer-b"},
+                ),
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["quote"]["quote_id"] != "qt-otherbuyer1"
+
 
 # =============================================================================
 # GET /api/v1/quotes/{quote_id}

--- a/tests/unit/test_quote_endpoints.py
+++ b/tests/unit/test_quote_endpoints.py
@@ -415,6 +415,101 @@ class TestCreateQuote:
 
 
 # =============================================================================
+# POST /api/v1/quotes — idempotency (FD-12, issue #44)
+# =============================================================================
+
+
+class TestQuoteIdempotency:
+    async def test_replay_same_key_same_body_returns_same_quote(self, client, mock_storage):
+        """Replaying an identical request with the same key mints no second quote."""
+        with (
+            patch(
+                "ad_seller.interfaces.api.main._get_static_product_catalog",
+                return_value=_mock_catalog(_products()),
+            ),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            body = _body(
+                idempotency_key="idem-replay-1",
+                product_id="ctv-premium-sports",
+                deal_type="PD",
+                impressions=5000000,
+            )
+            first = await client.post("/api/v1/quotes", json=body)
+            second = await client.post("/api/v1/quotes", json=body)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json()["quote"]["quote_id"] == second.json()["quote"]["quote_id"]
+        # Only one quote record was ever persisted.
+        quote_keys = [k for k in mock_storage._store if k.startswith("quote:")]
+        assert len(quote_keys) == 1
+
+    async def test_reused_key_different_body_returns_409(self, client, mock_storage):
+        """Same idempotency_key with a different payload is a conflict, not a new quote."""
+        with (
+            patch(
+                "ad_seller.interfaces.api.main._get_static_product_catalog",
+                return_value=_mock_catalog(_products()),
+            ),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            first = await client.post(
+                "/api/v1/quotes",
+                json=_body(
+                    idempotency_key="idem-conflict-1",
+                    product_id="ctv-premium-sports",
+                    deal_type="PD",
+                    impressions=1000000,
+                ),
+            )
+            second = await client.post(
+                "/api/v1/quotes",
+                json=_body(
+                    idempotency_key="idem-conflict-1",
+                    product_id="ctv-premium-sports",
+                    deal_type="PD",
+                    impressions=9999999,
+                ),
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 409
+        assert second.json()["detail"]["error"] == "idempotency_conflict"
+
+    async def test_different_keys_mint_separate_quotes(self, client, mock_storage):
+        with (
+            patch(
+                "ad_seller.interfaces.api.main._get_static_product_catalog",
+                return_value=_mock_catalog(_products()),
+            ),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            first = await client.post(
+                "/api/v1/quotes",
+                json=_body(
+                    idempotency_key="idem-a",
+                    product_id="ctv-premium-sports",
+                    deal_type="PD",
+                    impressions=1000000,
+                ),
+            )
+            second = await client.post(
+                "/api/v1/quotes",
+                json=_body(
+                    idempotency_key="idem-b",
+                    product_id="ctv-premium-sports",
+                    deal_type="PD",
+                    impressions=1000000,
+                ),
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json()["quote"]["quote_id"] != second.json()["quote"]["quote_id"]
+
+
+# =============================================================================
 # GET /api/v1/quotes/{quote_id}
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #44. `POST /api/v1/quotes` requires `idempotency_key` (422 without it) but never honored it — replaying an identical request minted a new quote on every call. `POST /api/v1/deals` implements FD-12 correctly on the same surface, which is what made this look like an asymmetry rather than unfinished work.

Per [the maintainer's confirmation on the issue](https://github.com/IABTechLab/seller-agent/issues/44#issuecomment-5246886856):
1. A prior quote is a covered money-mutating operation under FD-12 — the gap is a bug, not a deliberate exclusion.
2. The key is intentionally required, no silent auto-minting.
3. A reused key with a different payload should return `idempotency_conflict`, mapped to HTTP 409.

The comment also flagged that `/deals` only detects *replay* (same key → same deal) but never detects *conflict* (same key, different body silently books whichever quote wins the race) — "welcome on both surfaces."

## Changes

**`contract_mappers.py`** — two new helpers:
- `idempotency_conflict_detail()`, mirroring the existing `unsupported_capability_detail()` pattern, builds the shared `ErrorDetail(error=ErrorCode.IDEMPOTENCY_CONFLICT)` envelope.
- `request_payload_hash()`, a stable sha256 over `request.model_dump(mode="json", exclude={"idempotency_key"})` — used to tell a true replay from a conflicting reuse.

**`routers/quotes.py`** — mirrors the `/deals` idempotency pattern under an `idempotency:quote:{key}` storage namespace:
- Replay with a matching payload hash returns the original quote (via `quote_service.get_quote`), no second quote minted.
- Replay with a different hash raises `409 idempotency_conflict`.

**`routers/deals.py`** — closes the conflict-detection gap: previously any two different bodies under the same key would just book whichever request completed first booking (silent, no error). Now a payload-hash mismatch under a reused key returns `409 idempotency_conflict`, same as quotes.

## Test plan

- [x] 3 new tests in `test_quote_endpoints.py::TestQuoteIdempotency` — replay returns same quote (and only one quote record persisted), reused key + different body → 409, different keys → separate quotes
- [x] 1 new test in `test_deal_booking_endpoints.py::TestBookDeal` — reused key against a different `quote_id` → 409
- [x] Existing replay/error-path tests on both endpoints pass unchanged
- [x] Full unit suite: 1397 passed, no regressions
- [x] `ruff check` / `ruff format --check` clean

Closes #44