### PR TITLE
fix: enforce idempotency on POST /api/v1/negotiations/messages

### DIFF
--- a/src/ad_seller/interfaces/api/routers/negotiation.py
+++ b/src/ad_seller/interfaces/api/routers/negotiation.py
@@ -103,6 +103,13 @@ async def post_negotiation_message(
     bug). Priced actions (counter/final_offer) run the seller's untouched
     negotiation engine; accept/reject are recorded as terminal rounds off
     the existing history.
+
+    **Idempotency (FD-12):** the request carries a required
+    ``idempotency_key``. A replay with a key already used for an identical
+    body returns the same round without consuming another one from the
+    negotiation's ``max_rounds`` budget; the same key reused with a
+    different body is an ``idempotency_conflict`` (HTTP 409). The key is
+    scoped per buyer, same as ``/api/v1/quotes`` and ``/api/v1/deals``.
     """
     # EP-5.2: cap the claimed tier at a verified ceiling. The shared
     # NegotiationMessage carries no agent_url (lib gap — QuoteRequest has
@@ -141,18 +148,62 @@ async def post_negotiation_message(
 
     buyer_price = cm.money_to_float(message.buyer_price)
 
+    # Idempotency (FD-12): every negotiation message — priced or terminal —
+    # requires idempotency_key on the wire. Scoped per buyer (mirrors
+    # /api/v1/quotes and /api/v1/deals): a global namespace would let two
+    # buyers collide on the same client-chosen key. Checked before either
+    # branch below runs, since a replayed "counter" must return the
+    # original round rather than append a second one to a budget-limited
+    # negotiation (max_rounds), and a replayed "accept"/"reject" must not
+    # re-apply a terminal move.
+    from ....storage.factory import get_storage
+
+    idem_storage_key = (
+        f"idempotency:negotiation:{buyer_context.get_pricing_key()}:{message.idempotency_key}"
+    )
+    payload_hash = cm.request_payload_hash(
+        message.model_dump(mode="json", exclude={"idempotency_key"})
+    )
+    storage = await get_storage()
+    try:
+        prior = await storage.get(idem_storage_key)
+    except Exception:
+        prior = None
+    if isinstance(prior, dict) and prior.get("response"):
+        if prior.get("payload_hash") != payload_hash:
+            raise HTTPException(
+                status_code=409,
+                detail=cm.idempotency_conflict_detail(
+                    f"idempotency_key '{message.idempotency_key}' was already used "
+                    "for a different negotiation message."
+                ),
+            )
+        return NegotiationRoundResponse(**prior["response"])
+
     if message.action in PRICED_ACTIONS:
         result = await negotiation_service.counter_proposal(
             proposal_id=proposal_id,
             buyer_price=buyer_price,
             buyer_context=buyer_context,
         )
-        return cm.negotiation_round_to_response(result)
+        response = cm.negotiation_round_to_response(result)
+    else:
+        # accept / reject — terminal moves off the recorded history; the
+        # price engine is not run (it stays untouched). The move is
+        # PERSISTED onto the stored negotiation so downstream booking sees
+        # the agreed state.
+        status_data = await negotiation_service.apply_terminal_action(
+            proposal_id, message.action.value, buyer_price
+        )
+        response = cm.terminal_round_response(status_data, message.action, buyer_price)
 
-    # accept / reject — terminal moves off the recorded history; the price
-    # engine is not run (it stays untouched). The move is PERSISTED onto the
-    # stored negotiation so downstream booking sees the agreed state.
-    status_data = await negotiation_service.apply_terminal_action(
-        proposal_id, message.action.value, buyer_price
-    )
-    return cm.terminal_round_response(status_data, message.action, buyer_price)
+    try:
+        await storage.set(
+            idem_storage_key,
+            {"response": response.model_dump(mode="json"), "payload_hash": payload_hash},
+            ttl=86400,
+        )
+    except Exception:
+        pass
+
+    return response

--- a/tests/unit/test_negotiation_message_endpoint.py
+++ b/tests/unit/test_negotiation_message_endpoint.py
@@ -56,11 +56,35 @@ def client():
     app.dependency_overrides.clear()
 
 
+@pytest.fixture
+def mock_storage():
+    """In-memory dict-backed mock storage.
+
+    Stubs both the generic KV path (idempotency) and get_negotiation, since
+    apply_terminal_action reads the latter directly — an un-stubbed
+    AsyncMock attribute returns a truthy Mock, not None, which breaks its
+    "no stored negotiation" no-op path.
+    """
+    store = {}
+    storage = AsyncMock()
+    storage.get = AsyncMock(side_effect=lambda k: store.get(k))
+    storage.set = AsyncMock(side_effect=lambda k, v, ttl=None: store.__setitem__(k, v))
+    storage.get_negotiation = AsyncMock(side_effect=lambda pid: store.get(f"negotiation:{pid}"))
+    storage.set_negotiation = AsyncMock(
+        side_effect=lambda pid, data: store.__setitem__(f"negotiation:{pid}", data)
+    )
+    storage._store = store
+    return storage
+
+
 class TestSharedNegotiationMessage:
-    async def test_counter_with_money_and_action_is_accepted(self, client):
+    async def test_counter_with_money_and_action_is_accepted(self, client, mock_storage):
         """A well-formed shared counter validates and returns the shared round."""
         counter = AsyncMock(return_value=_COUNTER_RESULT)
-        with patch("ad_seller.services.negotiation_service.counter_proposal", new=counter):
+        with (
+            patch("ad_seller.services.negotiation_service.counter_proposal", new=counter),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
             async with client as c:
                 resp = await c.post(
                     "/api/v1/negotiations/messages",
@@ -120,7 +144,7 @@ class TestSharedNegotiationMessage:
             )
         assert resp.status_code == 422
 
-    async def test_reject_records_terminal_round(self, client):
+    async def test_reject_records_terminal_round(self, client, mock_storage):
         """A walk-away is recorded as a terminal round, not silently dropped."""
         status_data = {
             "negotiation_id": "neg-9",
@@ -134,9 +158,12 @@ class TestSharedNegotiationMessage:
                 }
             ],
         }
-        with patch(
-            "ad_seller.services.negotiation_service.get_negotiation_status",
-            new=AsyncMock(return_value=status_data),
+        with (
+            patch(
+                "ad_seller.services.negotiation_service.get_negotiation_status",
+                new=AsyncMock(return_value=status_data),
+            ),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
         ):
             async with client as c:
                 resp = await c.post(
@@ -153,3 +180,100 @@ class TestSharedNegotiationMessage:
         assert body["status"] == "rejected"
         assert body["round"]["action"] == "reject"
         assert body["round"]["buyer_price"]["amount_micros"] == 24_000_000
+
+
+# =============================================================================
+# POST /api/v1/negotiations/messages — idempotency (FD-12, issue #51)
+# =============================================================================
+
+
+class TestNegotiationMessageIdempotency:
+    async def test_replay_same_key_same_body_returns_same_round_no_second_call(
+        self, client, mock_storage
+    ):
+        """Replaying an identical counter must not consume a second round
+        from the negotiation's max_rounds budget."""
+        counter = AsyncMock(return_value=_COUNTER_RESULT)
+        body = {
+            "idempotency_key": "idem-replay-1",
+            "action": "counter",
+            "proposal_id": "prop-1",
+            "buyer_price": {"amount_micros": 25_000_000, "currency": "USD"},
+        }
+        with (
+            patch("ad_seller.services.negotiation_service.counter_proposal", new=counter),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            async with client as c:
+                first = await c.post("/api/v1/negotiations/messages", json=body)
+                second = await c.post("/api/v1/negotiations/messages", json=body)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        # The underlying negotiation engine ran exactly once.
+        assert counter.await_count == 1
+
+    async def test_reused_key_different_body_returns_409(self, client, mock_storage):
+        """Same idempotency_key with a different buyer_price is a conflict,
+        not a second round."""
+        counter = AsyncMock(return_value=_COUNTER_RESULT)
+        with (
+            patch("ad_seller.services.negotiation_service.counter_proposal", new=counter),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            async with client as c:
+                first = await c.post(
+                    "/api/v1/negotiations/messages",
+                    json={
+                        "idempotency_key": "idem-conflict-1",
+                        "action": "counter",
+                        "proposal_id": "prop-1",
+                        "buyer_price": {"amount_micros": 25_000_000, "currency": "USD"},
+                    },
+                )
+                second = await c.post(
+                    "/api/v1/negotiations/messages",
+                    json={
+                        "idempotency_key": "idem-conflict-1",
+                        "action": "counter",
+                        "proposal_id": "prop-1",
+                        "buyer_price": {"amount_micros": 27_000_000, "currency": "USD"},
+                    },
+                )
+
+        assert first.status_code == 200
+        assert second.status_code == 409
+        assert second.json()["detail"]["error"] == "idempotency_conflict"
+        assert counter.await_count == 1
+
+    async def test_idempotency_key_scoped_per_buyer(self, client, mock_storage):
+        """A record stored under one buyer's scope must not short-circuit a
+        different buyer reusing the same client-chosen key."""
+        counter = AsyncMock(return_value=_COUNTER_RESULT)
+        # As if a different buyer already used this exact key.
+        mock_storage._store["idempotency:negotiation:public:idem-shared"] = {
+            "response": {**_COUNTER_RESULT, "negotiation_id": "neg-other-buyer"},
+            "payload_hash": "not-the-real-hash",
+        }
+        with (
+            patch("ad_seller.services.negotiation_service.counter_proposal", new=counter),
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+        ):
+            async with client as c:
+                resp = await c.post(
+                    "/api/v1/negotiations/messages",
+                    json={
+                        "idempotency_key": "idem-shared",
+                        "action": "counter",
+                        "proposal_id": "prop-1",
+                        "buyer_price": {"amount_micros": 25_000_000, "currency": "USD"},
+                        "buyer_identity": {"advertiser_id": "adv-buyer-b"},
+                    },
+                )
+
+        assert resp.status_code == 200
+        # Reached the real engine — the other buyer's stored record was
+        # correctly scoped out of this buyer's lookup.
+        assert counter.await_count == 1
+        assert resp.json()["negotiation_id"] != "neg-other-buyer"


### PR DESCRIPTION
## Summary

Fixes #51. `NegotiationMessage` requires `idempotency_key` (inherited from `IdempotentRequest` — the same base class as `QuoteRequest`/`DealBookingRequest`, a 422 without it), but neither the router nor `negotiation_service` ever read the field. Same bug class as #44 (fixed for quotes/deals in #50), on a surface that wasn't covered by that fix.

This one is worse than the quotes case: negotiations have a hard `max_rounds` budget (3–6 depending on tier). Every `counter_proposal` call unconditionally appends a round with no replay check, so a client retry of a timed-out counter — the exact scenario `idempotency_key` exists to make safe — burns an extra round instead of returning the original response. Enough retries can push a legitimate negotiation past `max_rounds` into an unintended REJECT/walk-away.

Reproduced live before fixing (see #51 for the full repro): identical `idempotency_key` + identical body, two requests → second call minted `round_number=2` and `rounds_remaining` dropped 2→1 from a single retry.

## Changes

Mirrors the #50 pattern in `routers/negotiation.py`'s `post_negotiation_message`:

- Checks an `idempotency:negotiation:{buyer_scope}:{key}` storage record before running either branch — the field is required on every action (accept/reject/counter/final_offer), not just the priced ones, so the check runs once up front rather than duplicated per-branch.
- On a payload-hash match: replays the stored response instead of re-running the engine or re-applying a terminal move.
- On a payload-hash mismatch: `409 idempotency_conflict`, reusing `contract_mappers.idempotency_conflict_detail()` / `request_payload_hash()` from #50.
- Scoped per buyer via `BuyerContext.get_pricing_key()` (same specificity order as quotes/deals) — a global namespace would let two buyers collide on the same client-chosen key.

## Test plan

- 3 new tests in `test_negotiation_message_endpoint.py::TestNegotiationMessageIdempotency`:
  - replay (same key + body) returns the identical response and the negotiation engine is called exactly once
  - reused key + different `buyer_price` → 409, engine still called only once
  - a record stored under a different buyer's scope doesn't short-circuit this buyer's request
- Two pre-existing tests in the same file didn't mock storage — harmless before this change (nothing in the request path touched it), but now that the endpoint has real storage-backed idempotency, an un-mocked call falls through to whichever storage backend is actually configured. Fixed both to mock storage explicitly, matching the convention already used in `test_deal_booking_endpoints.py` / `test_quote_endpoints.py`.
- Full suite: 1403 passed (1400 + 3 new). `ruff check` / `format --check` clean.

Closes #51