### PR TITLE
fix: don't stack a higher-priority discount rule onto a price override

### DIFF
--- a/src/ad_seller/engines/pricing_rules_engine.py
+++ b/src/ad_seller/engines/pricing_rules_engine.py
@@ -123,8 +123,14 @@ class PricingRulesEngine:
         # A higher-priority rule's discount can already be sitting in
         # rule_discount by the time we hit the override below it in the
         # list — don't let it sneak back in and knock more off an override
-        # price that's supposed to be the final word.
-        if rule_discount > 0 and not override_applied:
+        # price that's supposed to be the final word. Reset it outright
+        # rather than just skipping the price multiply: rule_discount also
+        # feeds the rationale string below, and a leftover value there
+        # would have the rationale claim a discount that was never
+        # actually applied to the override price.
+        if override_applied:
+            rule_discount = 0.0
+        elif rule_discount > 0:
             price = price * (1 - rule_discount)
             applied_rules.append(f"Rule discount: -{rule_discount * 100:.0f}%")
 

--- a/src/ad_seller/engines/pricing_rules_engine.py
+++ b/src/ad_seller/engines/pricing_rules_engine.py
@@ -107,18 +107,24 @@ class PricingRulesEngine:
         )
 
         rule_discount = 0.0
+        override_applied = False
         for rule in matching_rules:
             if rule.base_price_override is not None:
                 price = rule.base_price_override
                 applied_rules.append(
                     f"Rule '{rule.rule_name}': Price override ${rule.base_price_override}"
                 )
-                break  # Price override takes precedence
+                override_applied = True
+                break  # Price override takes precedence, stop evaluating rules
 
             if rule.discount_percentage > 0:
                 rule_discount = max(rule_discount, rule.discount_percentage)
 
-        if rule_discount > 0:
+        # A higher-priority rule's discount can already be sitting in
+        # rule_discount by the time we hit the override below it in the
+        # list — don't let it sneak back in and knock more off an override
+        # price that's supposed to be the final word.
+        if rule_discount > 0 and not override_applied:
             price = price * (1 - rule_discount)
             applied_rules.append(f"Rule discount: -{rule_discount * 100:.0f}%")
 

--- a/tests/unit/test_pricing_engine.py
+++ b/tests/unit/test_pricing_engine.py
@@ -13,9 +13,9 @@ Focuses on:
 import pytest
 
 from ad_seller.engines.pricing_rules_engine import PricingRulesEngine
-from ad_seller.models.buyer_identity import BuyerContext, BuyerIdentity
+from ad_seller.models.buyer_identity import AccessTier, BuyerContext, BuyerIdentity
 from ad_seller.models.core import PricingModel
-from ad_seller.models.pricing_tiers import TieredPricingConfig
+from ad_seller.models.pricing_tiers import PricingRule, TieredPricingConfig
 
 
 @pytest.fixture
@@ -190,3 +190,108 @@ class TestRateCardAndPriceDisplay:
         )
         assert result.pricing_model == PricingModel.CPM
         assert result.currency == "USD"
+
+
+class TestPriceOverrideRules:
+    """A rule's base_price_override is supposed to be the final word (per
+    docs/guides/pricing-rules.md: "takes precedence and stops further rule
+    evaluation"), not a starting point another rule's discount can still
+    chip away at.
+
+    Regression coverage for issue #53: a higher-priority discount-only
+    rule was leaving its discount in a shared accumulator that got applied
+    to the override price after the loop had already moved past it.
+    """
+
+    def test_override_alone_replaces_base_price(self, engine, agency_buyer_context):
+        engine.config.rules = [
+            PricingRule(
+                rule_id="r-override",
+                rule_name="Negotiated flat rate",
+                access_tier=AccessTier.AGENCY,
+                base_price_override=50.0,
+            ),
+        ]
+        result = engine.calculate_price(
+            product_id="p1", base_price=100.0, buyer_context=agency_buyer_context
+        )
+        assert result.final_price == 50.0
+
+    def test_override_wins_even_when_outranked_by_a_discount_rule(
+        self, engine, agency_buyer_context
+    ):
+        """The bug: a higher-priority discount-only rule gets evaluated
+        first (rules are sorted by priority), leaving its discount in the
+        loop's shared accumulator. Once the lower-priority override rule
+        is reached and the loop breaks, that stale discount must not be
+        applied on top of it."""
+        engine.config.rules = [
+            PricingRule(
+                rule_id="r-discount",
+                rule_name="Agency-wide discount",
+                priority=100,
+                access_tier=AccessTier.AGENCY,
+                discount_percentage=0.20,
+            ),
+            PricingRule(
+                rule_id="r-override",
+                rule_name="Negotiated flat rate",
+                priority=50,
+                access_tier=AccessTier.AGENCY,
+                base_price_override=50.0,
+            ),
+        ]
+        result = engine.calculate_price(
+            product_id="p1", base_price=100.0, buyer_context=agency_buyer_context
+        )
+        assert result.final_price == 50.0
+        assert not any("Rule discount" in r for r in result.applied_rules)
+
+    def test_override_wins_when_it_outranks_the_discount_rule(self, engine, agency_buyer_context):
+        """Same two rules, priority order flipped — the override was
+        already reached (and the loop broken) before the discount rule
+        would ever be visited, so this direction always worked."""
+        engine.config.rules = [
+            PricingRule(
+                rule_id="r-override",
+                rule_name="Negotiated flat rate",
+                priority=100,
+                access_tier=AccessTier.AGENCY,
+                base_price_override=50.0,
+            ),
+            PricingRule(
+                rule_id="r-discount",
+                rule_name="Agency-wide discount",
+                priority=50,
+                access_tier=AccessTier.AGENCY,
+                discount_percentage=0.20,
+            ),
+        ]
+        result = engine.calculate_price(
+            product_id="p1", base_price=100.0, buyer_context=agency_buyer_context
+        )
+        assert result.final_price == 50.0
+
+    def test_discount_only_rules_still_apply_the_highest_one(self, engine, agency_buyer_context):
+        """No override in play: this path is untouched by the fix."""
+        engine.config.rules = [
+            PricingRule(
+                rule_id="r-small",
+                rule_name="Small discount",
+                priority=100,
+                access_tier=AccessTier.AGENCY,
+                discount_percentage=0.05,
+            ),
+            PricingRule(
+                rule_id="r-big",
+                rule_name="Bigger discount",
+                priority=50,
+                access_tier=AccessTier.AGENCY,
+                discount_percentage=0.20,
+            ),
+        ]
+        result = engine.calculate_price(
+            product_id="p1", base_price=100.0, buyer_context=agency_buyer_context
+        )
+        # Tier discount (10%) then the higher of the two rule discounts (20%).
+        assert result.final_price == pytest.approx(100.0 * 0.9 * 0.8)

--- a/tests/unit/test_pricing_engine.py
+++ b/tests/unit/test_pricing_engine.py
@@ -247,6 +247,35 @@ class TestPriceOverrideRules:
         assert result.final_price == 50.0
         assert not any("Rule discount" in r for r in result.applied_rules)
 
+    def test_rationale_does_not_claim_an_unapplied_discount(self, engine, agency_buyer_context):
+        """Review follow-up on #54: applied_rules correctly omitted the
+        stale discount, but rule_discount still fed the rationale string
+        unchanged, so the human-readable text claimed a 'Custom rule: -20%'
+        that was never actually taken off the override price. That string
+        reaches quotes, negotiated-deal text, and MCP/API responses, where
+        a counterparty could anchor on a discount that doesn't exist."""
+        engine.config.rules = [
+            PricingRule(
+                rule_id="r-discount",
+                rule_name="Agency-wide discount",
+                priority=100,
+                access_tier=AccessTier.AGENCY,
+                discount_percentage=0.20,
+            ),
+            PricingRule(
+                rule_id="r-override",
+                rule_name="Negotiated flat rate",
+                priority=50,
+                access_tier=AccessTier.AGENCY,
+                base_price_override=50.0,
+            ),
+        ]
+        result = engine.calculate_price(
+            product_id="p1", base_price=100.0, buyer_context=agency_buyer_context
+        )
+        assert "Custom rule" not in result.rationale
+        assert "Final price: $50.00" in result.rationale
+
     def test_override_wins_when_it_outranks_the_discount_rule(self, engine, agency_buyer_context):
         """Same two rules, priority order flipped — the override was
         already reached (and the loop broken) before the discount rule


### PR DESCRIPTION
## Summary

Fixes #53. `PricingRulesEngine.calculate_price` scans `matching_rules` (sorted by priority, descending) and breaks as soon as it finds a rule with `base_price_override`, with a comment saying the override "takes precedence." It does — for the running `price` variable. But a `discount_percentage` from a rule visited *earlier* in the same loop (a higher-priority rule with no override of its own) stays in the shared `rule_discount` accumulator and gets multiplied into the override price after the loop exits.

Verified against `docs/guides/pricing-rules.md` before filing #53 — it draws override and discount as mutually exclusive branches off the same decision point, and states an override "stops further rule evaluation." The current code does the opposite whenever a higher-priority discount-only rule happens to be scanned first.

## Concrete impact

A seller configures a $50 flat negotiated rate for an agency (priority 50), alongside an unrelated agency-wide 20% discount rule (priority 100, no override). The discount rule is evaluated first — it outranks the override rule — leaving `0.20` in `rule_discount`. The override rule is then reached, sets `price = 50`, and breaks. The stale `0.20` still gets applied afterward: the buyer lands at **$40** instead of the **$50** the seller configured. Revenue leak, silent.

## Fix

Track whether an override fired (`override_applied`) and skip the trailing discount-application block when it did. The discount-only path (no override in play, multiple discount rules competing) is untouched — still takes the highest discount, not stacked, as documented.

```python
rule_discount = 0.0
override_applied = False
for rule in matching_rules:
    if rule.base_price_override is not None:
        price = rule.base_price_override
        ...
        override_applied = True
        break

    if rule.discount_percentage > 0:
        rule_discount = max(rule_discount, rule.discount_percentage)

if rule_discount > 0 and not override_applied:
    price = price * (1 - rule_discount)
    ...
```

## Test plan

`base_price_override` had **zero** test coverage before this — that's how the bug survived since the initial commit. Added `TestPriceOverrideRules` in `test_pricing_engine.py`:

- override alone replaces the base price
- override wins even when outranked (lower priority) by a discount-only rule — the case that was broken
- override wins when it outranks the discount rule — the case that already worked, kept as a regression guard
- discount-only rules (no override) still apply the highest one, not stacked — confirms the fix didn't touch the unrelated path

Full suite: 1404 passed, no regressions. `ruff check` / `format --check` clean.

Closes #53