### PR TITLE
fix: reject migrating an already-migrated deal, don't fork lineage

### DIFF
--- a/src/ad_seller/services/deal_service.py
+++ b/src/ad_seller/services/deal_service.py
@@ -1372,6 +1372,23 @@ async def migrate_deal(deal_id: str, request: Any) -> dict[str, Any]:
             detail={"error": "deal_not_found", "message": f"Deal '{deal_id}' not found."},
         )
 
+    # A deal that's already been migrated (or deprecated some other way)
+    # can't be migrated again — the code below would happily overwrite
+    # replacement_deal_id with a brand new deal, and the deal it had
+    # previously pointed to would still be sitting there fully active but
+    # unreachable from lineage. Same guard deprecate_deal already has for
+    # the same reason, one function down.
+    if old_deal.get("status") == "deprecated":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "already_deprecated",
+                "message": f"Deal '{deal_id}' is already deprecated and cannot be migrated again.",
+                "deprecated_at": old_deal.get("deprecated_at"),
+                "replacement_deal_id": old_deal.get("replacement_deal_id"),
+            },
+        )
+
     # Build new deal from old deal + overrides
     now = datetime.utcnow()
     new_deal_id = f"DEMO-{uuid.uuid4().hex[:12].upper()}"

--- a/tests/unit/test_deal_lineage.py
+++ b/tests/unit/test_deal_lineage.py
@@ -1,0 +1,195 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for deal migration, deprecation, and lineage (issue #55).
+
+migrate_deal, deprecate_deal, and get_deal_lineage had zero test coverage
+before this file. That's how a migrate_deal double-call went unnoticed:
+it has no guard against acting on an already-deprecated deal, unlike its
+sibling deprecate_deal, so calling /migrate twice on the same deal_id
+silently orphaned the first replacement and forked the lineage chain.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from ad_seller.services import deal_service
+
+
+@pytest.fixture
+def mock_storage():
+    store = {}
+    storage = AsyncMock()
+    storage.get_deal = AsyncMock(side_effect=lambda did: store.get(did))
+    storage.set_deal = AsyncMock(side_effect=lambda did, data: store.__setitem__(did, data))
+    storage._store = store
+    return storage
+
+
+def _make_deal(**overrides):
+    defaults = {
+        "deal_id": "DEAL-ORIG",
+        "deal_type": "PD",
+        "status": "confirmed",
+        "product_id": "ctv-premium-sports",
+        "actual_price_cpm": 30.0,
+        "impressions": 1_000_000,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _migration_request(**overrides):
+    defaults = dict(
+        deal_type=None,
+        product_id=None,
+        max_cpm=None,
+        impressions=None,
+        flight_start=None,
+        flight_end=None,
+        buyer_seat_ids=None,
+        reason="better supply path",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _deprecation_request(**overrides):
+    defaults = dict(reason="inventory retired", replacement_deal_id=None)
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestMigrateDeal:
+    async def test_happy_path_creates_lineage(self, mock_storage, monkeypatch):
+        mock_storage._store["DEAL-ORIG"] = _make_deal()
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        result = await deal_service.migrate_deal("DEAL-ORIG", _migration_request())
+
+        new_deal_id = result["new_deal_id"]
+        assert result["old_deal_id"] == "DEAL-ORIG"
+        assert result["lineage"]["parent_deal_id"] == "DEAL-ORIG"
+        assert result["lineage"]["replacement_deal_id"] == new_deal_id
+
+        old = mock_storage._store["DEAL-ORIG"]
+        assert old["status"] == "deprecated"
+        assert old["replacement_deal_id"] == new_deal_id
+
+        new = mock_storage._store[new_deal_id]
+        assert new["parent_deal_id"] == "DEAL-ORIG"
+        assert new["status"] == "confirmed"
+
+    async def test_not_found_returns_404(self, mock_storage, monkeypatch):
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.migrate_deal("DEAL-NOPE", _migration_request())
+        assert exc_info.value.status_code == 404
+
+    async def test_migrating_an_already_migrated_deal_is_rejected(self, mock_storage, monkeypatch):
+        """The bug: this used to silently create a second replacement and
+        orphan the first one instead of erroring, the same way a double
+        /deprecate call already errors."""
+        mock_storage._store["DEAL-ORIG"] = _make_deal()
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        first = await deal_service.migrate_deal("DEAL-ORIG", _migration_request())
+        first_replacement = first["new_deal_id"]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.migrate_deal("DEAL-ORIG", _migration_request(reason="retry"))
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"] == "already_deprecated"
+        assert exc_info.value.detail["replacement_deal_id"] == first_replacement
+
+        # No second replacement was created, and the first one is still
+        # correctly referenced — not orphaned.
+        assert mock_storage._store["DEAL-ORIG"]["replacement_deal_id"] == first_replacement
+        assert len(mock_storage._store) == 2  # original + first replacement only
+
+    async def test_overrides_take_priority_over_old_deal_values(self, mock_storage, monkeypatch):
+        mock_storage._store["DEAL-ORIG"] = _make_deal(impressions=1_000_000)
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        result = await deal_service.migrate_deal(
+            "DEAL-ORIG", _migration_request(impressions=2_000_000, max_cpm=40.0)
+        )
+
+        new_deal = result["new_deal"]
+        assert new_deal["impressions"] == 2_000_000
+        assert new_deal["actual_price_cpm"] == 40.0
+
+
+class TestDeprecateDeal:
+    async def test_happy_path(self, mock_storage, monkeypatch):
+        mock_storage._store["DEAL-ORIG"] = _make_deal()
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        result = await deal_service.deprecate_deal("DEAL-ORIG", _deprecation_request())
+
+        assert result["status"] == "deprecated"
+        assert mock_storage._store["DEAL-ORIG"]["status"] == "deprecated"
+
+    async def test_double_deprecate_returns_409(self, mock_storage, monkeypatch):
+        mock_storage._store["DEAL-ORIG"] = _make_deal()
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        await deal_service.deprecate_deal("DEAL-ORIG", _deprecation_request())
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.deprecate_deal("DEAL-ORIG", _deprecation_request())
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"] == "already_deprecated"
+
+
+class TestGetDealLineage:
+    async def test_single_migration_forward_lineage(self, mock_storage, monkeypatch):
+        mock_storage._store["DEAL-ORIG"] = _make_deal()
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        result = await deal_service.migrate_deal("DEAL-ORIG", _migration_request())
+        new_deal_id = result["new_deal_id"]
+
+        lineage = await deal_service.get_deal_lineage("DEAL-ORIG")
+        assert [r["deal_id"] for r in lineage["replacements"]] == [new_deal_id]
+
+        lineage_from_new = await deal_service.get_deal_lineage(new_deal_id)
+        assert [p["deal_id"] for p in lineage_from_new["parents"]] == ["DEAL-ORIG"]
+
+    async def test_chain_of_two_migrations_stays_intact(self, mock_storage, monkeypatch):
+        """A legitimate multi-hop chain (A -> B, then B -> C, each called
+        on the CURRENT deal, never re-migrating an already-deprecated one)
+        must remain fully walkable in both directions."""
+        mock_storage._store["DEAL-A"] = _make_deal(deal_id="DEAL-A")
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        first = await deal_service.migrate_deal("DEAL-A", _migration_request())
+        deal_b = first["new_deal_id"]
+        second = await deal_service.migrate_deal(deal_b, _migration_request(reason="hop 2"))
+        deal_c = second["new_deal_id"]
+
+        lineage_from_a = await deal_service.get_deal_lineage("DEAL-A")
+        assert [r["deal_id"] for r in lineage_from_a["replacements"]] == [deal_b, deal_c]
+
+        lineage_from_c = await deal_service.get_deal_lineage(deal_c)
+        assert [p["deal_id"] for p in lineage_from_c["parents"]] == ["DEAL-A", deal_b]


### PR DESCRIPTION
## Summary

Fixes #55. `migrate_deal` had no check on the target deal's status before mutating it. Calling `POST /api/v1/deals/{deal_id}/migrate` twice on the same `deal_id` — a duplicate client call, a retry, an operator mistake — silently created a second replacement deal and overwrote the original deal's `replacement_deal_id` to point at it. The first replacement stayed fully `confirmed` and active in storage but became permanently unreachable from `get_deal_lineage`: no incoming or outgoing pointer, just dangling.

`deprecate_deal` already guards against the same class of problem — acting again on a deal that's already deprecated — with a `409 already_deprecated` error. `migrate_deal` does something strictly *more* mutating (creates a new deal **and** deprecates the old one) and had no equivalent guard, which is what let this through. See #55 for the full repro.

## Fix

Same check `migrate_deal`'s sibling already has: if the deal is already deprecated, `409` with the existing `replacement_deal_id` so the caller isn't left guessing where the prior migration went.

```python
if old_deal.get("status") == "deprecated":
    raise HTTPException(
        status_code=409,
        detail={
            "error": "already_deprecated",
            "message": f"Deal '{deal_id}' is already deprecated and cannot be migrated again.",
            "deprecated_at": old_deal.get("deprecated_at"),
            "replacement_deal_id": old_deal.get("replacement_deal_id"),
        },
    )
```

## Test plan

`migrate_deal`, `deprecate_deal`, and `get_deal_lineage` had **zero** test coverage before this. Added `tests/unit/test_deal_lineage.py`:

- happy path for all three functions
- the double-deprecate guard that already existed (regression guard)
- the new double-migrate guard — the exact bug from #55
- a legitimate two-hop migration chain (A→B, then B→C — migrating the *current* deal each time, never re-migrating an already-deprecated one) to confirm lineage still walks correctly forward and backward after the fix

Full suite: 1408 passed (1400 + 8 new), no regressions. `ruff check` / `format --check` clean.

Closes #55