### PR TITLE
fix: 404 an unknown product_id in curated deals, don't fabricate a price

### DIFF
--- a/src/ad_seller/services/deal_service.py
+++ b/src/ad_seller/services/deal_service.py
@@ -1233,14 +1233,25 @@ async def create_curated_deal(request: Any, catalog: dict[str, Any]) -> dict[str
         )
 
     # Get base price from product catalog. A known-but-unpriced product
-    # (no base/floor CPM) is a 422 — never a fabricated price.
-    base_cpm = 12.0  # Default
+    # (no base/floor CPM) is a 422 — never a fabricated price. A product_id
+    # that doesn't exist in the catalog at all is a 404, for the same
+    # reason — falling through to the no-product default here would price
+    # a typo'd/stale product_id at the generic $12 CPM instead of erroring.
+    base_cpm = 12.0  # Default when no product_id is supplied at all
     if request.product_id:
         product = catalog["products"].get(request.product_id)
-        if product:
-            from . import catalog_service
+        if not product:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "product_not_found",
+                    "message": f"Product '{request.product_id}' not found in catalog.",
+                },
+            )
 
-            base_cpm = catalog_service.priceable_cpm(product)
+        from . import catalog_service
+
+        base_cpm = catalog_service.priceable_cpm(product)
 
     # Calculate curated pricing
     curated_deal = registry.create_curated_deal(

--- a/tests/unit/test_curated_deal.py
+++ b/tests/unit/test_curated_deal.py
@@ -1,0 +1,131 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Unit tests for create_curated_deal (issue #57).
+
+create_curated_deal had zero test coverage before this file. That's how
+an unknown product_id went unnoticed silently falling back to a
+hardcoded $12 CPM default and minting a live, "confirmed" deal instead
+of 404ing -- the same honest-pricing guarantee the adjacent code comment
+claims to enforce, just missing for the "product doesn't exist at all"
+case rather than the "product exists but has no price" case it does
+cover.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from ad_seller.services import deal_service
+
+
+@pytest.fixture
+def mock_storage():
+    store = {}
+    storage = AsyncMock()
+    storage.set_deal = AsyncMock(side_effect=lambda did, data: store.__setitem__(did, data))
+    storage._store = store
+    return storage
+
+
+def _make_product(**overrides):
+    defaults = dict(product_id="ctv-premium-sports", base_cpm=45.0, floor_cpm=35.0)
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _catalog(*products):
+    return {"products": {p.product_id: p for p in products}}
+
+
+def _curated_request(**overrides):
+    defaults = dict(
+        curator_id="agent-range",
+        deal_type="PMP",
+        product_id=None,
+        audience_segments=[],
+        content_categories=[],
+        impressions=1_000_000,
+        max_cpm=None,
+        flight_start=None,
+        flight_end=None,
+        buyer_seat_ids=[],
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestCreateCuratedDeal:
+    async def test_unknown_product_id_returns_404_not_a_fabricated_price(
+        self, mock_storage, monkeypatch
+    ):
+        """The bug: a typo'd/stale product_id used to silently price the
+        deal at the $12 CPM no-product default and confirm it anyway."""
+        catalog = _catalog(_make_product(base_cpm=45.0, floor_cpm=35.0))
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        request = _curated_request(product_id="ctv-premiumm-sports")  # typo, not in catalog
+
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.create_curated_deal(request, catalog)
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"] == "product_not_found"
+        # No deal was minted off the phantom product reference.
+        assert mock_storage._store == {}
+
+    async def test_known_product_prices_off_its_real_base_cpm(self, mock_storage, monkeypatch):
+        catalog = _catalog(_make_product(base_cpm=45.0, floor_cpm=35.0))
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        request = _curated_request(product_id="ctv-premium-sports")
+        result = await deal_service.create_curated_deal(request, catalog)
+
+        assert result["pricing"]["base_cpm"] == 45.0
+        # Agent Range's default fee is 10% of base.
+        assert result["pricing"]["curator_fee_cpm"] == pytest.approx(4.5)
+        assert result["pricing"]["total_cpm"] == pytest.approx(49.5)
+
+    async def test_known_but_unpriced_product_is_422(self, mock_storage, monkeypatch):
+        """The case the original comment was already correctly handling --
+        confirms the fix didn't disturb it."""
+        catalog = _catalog(_make_product(base_cpm=None, floor_cpm=None))
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        request = _curated_request(product_id="ctv-premium-sports")
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.create_curated_deal(request, catalog)
+        assert exc_info.value.status_code == 422
+
+    async def test_no_product_id_uses_generic_default(self, mock_storage, monkeypatch):
+        """A curated deal with no product reference at all is a supported
+        generic case -- distinct from a product_id that fails to resolve."""
+        catalog = _catalog(_make_product())
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        request = _curated_request(product_id=None)
+        result = await deal_service.create_curated_deal(request, catalog)
+
+        assert result["pricing"]["base_cpm"] == 12.0
+
+    async def test_curator_not_found_returns_404(self, mock_storage, monkeypatch):
+        catalog = _catalog(_make_product())
+        monkeypatch.setattr(
+            "ad_seller.storage.factory.get_storage", AsyncMock(return_value=mock_storage)
+        )
+
+        request = _curated_request(curator_id="nonexistent-curator")
+        with pytest.raises(HTTPException) as exc_info:
+            await deal_service.create_curated_deal(request, catalog)
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"] == "curator_not_found"


### PR DESCRIPTION
## Summary

Fixes #57. `create_curated_deal`'s comment says *"A known-but-unpriced product... is a 422 — never a fabricated price,"* and the code delivers on that for a product that exists but has no `base_cpm`/`floor_cpm` (via `catalog_service.priceable_cpm`). It didn't deliver on it for a `product_id` that doesn't exist in the catalog at all: that case skipped price resolution entirely and fell through to the hardcoded `$12` CPM default meant only for the no-`product_id`-supplied case, then **minted and persisted a `confirmed` deal at that fabricated price**. No error, anywhere.

`POST /api/v1/deals/curated` has no auth dependency at all, so this was reachable by anyone — a typo, a stale product reference, a deliberately made-up `product_id` — and unlike a mispriced quote, this endpoint creates a live confirmed deal record directly, not something pending booking. See #57 for the full repro (typo'd product_id against a $45/$35 real product → confirmed deal at $13.20 total CPM).

## Fix

When `product_id` is supplied but not found in the catalog, `404 product_not_found` — the same error shape `quote_service.create_quote` already uses for the identical situation. The `$12` CPM default now only applies when no `product_id` is given at all, which the code was always treating as a separate, legitimate case (a generic curated deal with no specific product reference).

```python
base_cpm = 12.0  # Default when no product_id is supplied at all
if request.product_id:
    product = catalog["products"].get(request.product_id)
    if not product:
        raise HTTPException(
            status_code=404,
            detail={"error": "product_not_found", "message": f"Product '{request.product_id}' not found in catalog."},
        )
    from . import catalog_service
    base_cpm = catalog_service.priceable_cpm(product)
```

## Test plan

`create_curated_deal` had **zero** test coverage before this. Added `tests/unit/test_curated_deal.py`:

- unknown `product_id` → 404, no deal minted (the bug)
- known product prices off its real `base_cpm` + curator fee
- known-but-unpriced product → 422 (unchanged by this fix, confirms the existing guard still works)
- no `product_id` at all → generic $12 default (unchanged, confirms this legitimate case wasn't broken)
- `curator_not_found` → 404, for completeness

Full suite: 1408 passed, no regressions. `ruff check` / `format --check` clean.

Closes #57