### PR TITLE
Cleans up operator key management

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -41,6 +41,21 @@ ad-seller create-operator-key --label "Primary operator"
 
 Run this with the same storage config (`.env`) as the server so the key lands in the backend the server reads. The full key is printed **once** — store it securely.
 
+List operator keys (metadata only — secrets are never re-shown):
+
+```bash
+ad-seller list-operator-keys
+ad-seller list-operator-keys --include-inactive   # include revoked/expired
+```
+
+To revoke an operator key out-of-band (frees the label for reuse):
+
+```bash
+ad-seller delete-operator-key --label "Primary operator"
+# or
+ad-seller delete-operator-key --key-id key-a1b2c3d4
+```
+
 Subsequent operator keys can be minted over HTTP with an existing operator credential (see below).
 
 ## Operator Surface

--- a/docs/guides/agent-management.md
+++ b/docs/guides/agent-management.md
@@ -21,6 +21,14 @@ the first operator key with the CLI (no HTTP auth):
 ad-seller create-operator-key --label "Primary operator"
 ```
 
+List and revoke the same way:
+
+```bash
+ad-seller list-operator-keys
+ad-seller delete-operator-key --label "Primary operator"
+# or: ad-seller delete-operator-key --key-id key-a1b2c3d4
+```
+
 See [Authentication](../api/authentication.md) for the full operator surface.
 
 ### Create a Buyer API Key

--- a/docs/guides/developer-setup.md
+++ b/docs/guides/developer-setup.md
@@ -103,7 +103,7 @@ The admin REST/MCP surface requires an **operator** API key. Mint the first one 
 ad-seller create-operator-key --label "Primary operator"
 ```
 
-Save the printed API key — it is shown only once. Subsequent operator keys can be minted via `POST /auth/api-keys/operator` using this credential. Buyer keys for agents go through `POST /auth/api-keys`. See [Authentication](../api/authentication.md).
+Save the printed API key — it is shown only once. Subsequent operator keys can be minted via `POST /auth/api-keys/operator` using this credential. List with `ad-seller list-operator-keys`; revoke out-of-band with `ad-seller delete-operator-key --label "Primary operator"` (or `--key-id ...`). Buyer keys for agents go through `POST /auth/api-keys`. See [Authentication](../api/authentication.md).
 
 ## Step 7: Generate Claude Desktop Config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ all = [
 ]
 
 [project.scripts]
-ad-seller = "ad_seller.interfaces.cli.main:app"
+ad-seller = "ad_seller.interfaces.cli.main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/ad_seller/auth/api_key_service.py
+++ b/src/ad_seller/auth/api_key_service.py
@@ -225,17 +225,13 @@ class ApiKeyService:
                 results.append(info)
         return results
 
-    async def list_operator_keys(
-        self, *, include_inactive: bool = False
-    ) -> list[ApiKeyInfo]:
+    async def list_operator_keys(self, *, include_inactive: bool = False) -> list[ApiKeyInfo]:
         """List OPERATOR-role API keys (metadata only, no secrets).
 
         By default returns only active keys. Pass ``include_inactive=True``
         to also include revoked/expired operator keys.
         """
-        keys = [
-            info for info in await self.list_keys() if info.role == ApiKeyRole.OPERATOR
-        ]
+        keys = [info for info in await self.list_keys() if info.role == ApiKeyRole.OPERATOR]
         if not include_inactive:
             keys = [info for info in keys if info.is_active]
         return keys
@@ -304,16 +300,10 @@ class ApiKeyService:
             matches = [
                 info
                 for info in await self.list_keys()
-                if (
-                    info.role == ApiKeyRole.OPERATOR
-                    and info.is_active
-                    and info.label == label
-                )
+                if (info.role == ApiKeyRole.OPERATOR and info.is_active and info.label == label)
             ]
             if not matches:
-                raise ValueError(
-                    f"No active operator key with label {label!r} found"
-                )
+                raise ValueError(f"No active operator key with label {label!r} found")
             if len(matches) > 1:
                 ids = ", ".join(m.key_id for m in matches)
                 raise ValueError(
@@ -324,8 +314,7 @@ class ApiKeyService:
 
         if not target.is_active:
             raise ValueError(
-                f"Operator key {target.key_id!r} is already inactive "
-                f"(revoked or expired)"
+                f"Operator key {target.key_id!r} is already inactive (revoked or expired)"
             )
 
         revoked = await self.revoke_key(target.key_id)

--- a/src/ad_seller/auth/api_key_service.py
+++ b/src/ad_seller/auth/api_key_service.py
@@ -69,9 +69,26 @@ class ApiKeyService:
     ) -> ApiKeyCreateResponse:
         """Issue a new OPERATOR-role API key (no buyer identity).
 
+        Rejects if an active (non-revoked, non-expired) operator key
+        already uses the same label. Revoked/expired labels may be reused.
+
         Returns the full key exactly once. The key is hashed
         before storage and can never be retrieved again.
+
+        Raises:
+            ValueError: If an active operator key already has this label.
         """
+        for existing in await self.list_keys():
+            if (
+                existing.role == ApiKeyRole.OPERATOR
+                and existing.is_active
+                and existing.label == request.label
+            ):
+                raise ValueError(
+                    f"An active operator key with label {request.label!r} "
+                    f"already exists ({existing.key_id})"
+                )
+
         return await self._mint(
             identity=BuyerIdentity(),
             role=ApiKeyRole.OPERATOR,
@@ -208,6 +225,21 @@ class ApiKeyService:
                 results.append(info)
         return results
 
+    async def list_operator_keys(
+        self, *, include_inactive: bool = False
+    ) -> list[ApiKeyInfo]:
+        """List OPERATOR-role API keys (metadata only, no secrets).
+
+        By default returns only active keys. Pass ``include_inactive=True``
+        to also include revoked/expired operator keys.
+        """
+        keys = [
+            info for info in await self.list_keys() if info.role == ApiKeyRole.OPERATOR
+        ]
+        if not include_inactive:
+            keys = [info for info in keys if info.is_active]
+        return keys
+
     async def revoke_key(self, key_id: str) -> bool:
         """Revoke an API key. Returns True if found and revoked."""
         key_hash = await self._storage.get(f"{API_KEY_INDEX_PREFIX}{key_id}")
@@ -229,3 +261,77 @@ class ApiKeyService:
 
         logger.info("API key %s revoked", key_id)
         return True
+
+    async def delete_operator_key(
+        self,
+        *,
+        key_id: Optional[str] = None,
+        label: Optional[str] = None,
+    ) -> ApiKeyInfo:
+        """Revoke an OPERATOR-role API key by key_id or label (bootstrap).
+
+        Soft-revokes so the label can be reused by a subsequent
+        ``create_operator_key``. Refuses buyer keys — use
+        ``revoke_key`` / ``DELETE /auth/api-keys/{key_id}`` for those.
+
+        Args:
+            key_id: Exact key id (e.g. ``key-a1b2c3d4``). Takes precedence
+                over ``label`` when both are provided.
+            label: Label of an active operator key to revoke.
+
+        Returns:
+            ``ApiKeyInfo`` for the revoked key.
+
+        Raises:
+            ValueError: If neither identifier is given, the key is missing,
+                is not an operator key, or is already inactive.
+        """
+        if not key_id and not label:
+            raise ValueError("Provide key_id or label to delete an operator key")
+
+        target: Optional[ApiKeyInfo] = None
+        if key_id:
+            target = await self.get_key_info(key_id)
+            if target is None:
+                raise ValueError(f"API key {key_id!r} not found")
+            if target.role != ApiKeyRole.OPERATOR:
+                raise ValueError(
+                    f"API key {key_id!r} is a {target.role.value} key, not an "
+                    "operator key. Use DELETE /auth/api-keys/{key_id} to revoke "
+                    "buyer keys."
+                )
+        else:
+            matches = [
+                info
+                for info in await self.list_keys()
+                if (
+                    info.role == ApiKeyRole.OPERATOR
+                    and info.is_active
+                    and info.label == label
+                )
+            ]
+            if not matches:
+                raise ValueError(
+                    f"No active operator key with label {label!r} found"
+                )
+            if len(matches) > 1:
+                ids = ", ".join(m.key_id for m in matches)
+                raise ValueError(
+                    f"Multiple active operator keys share label {label!r} "
+                    f"({ids}); pass --key-id to disambiguate"
+                )
+            target = matches[0]
+
+        if not target.is_active:
+            raise ValueError(
+                f"Operator key {target.key_id!r} is already inactive "
+                f"(revoked or expired)"
+            )
+
+        revoked = await self.revoke_key(target.key_id)
+        if not revoked:
+            raise ValueError(f"Failed to revoke operator key {target.key_id!r}")
+
+        info = await self.get_key_info(target.key_id)
+        assert info is not None  # just revoked in place
+        return info

--- a/src/ad_seller/interfaces/api/routers/admin.py
+++ b/src/ad_seller/interfaces/api/routers/admin.py
@@ -139,12 +139,15 @@ async def create_operator_api_key(
     storage = await get_storage()
     service = ApiKeyService(storage)
 
-    response = await service.create_operator_key(
-        OperatorApiKeyCreateRequest(
-            label=request.label,
-            expires_in_days=request.expires_in_days,
+    try:
+        response = await service.create_operator_key(
+            OperatorApiKeyCreateRequest(
+                label=request.label,
+                expires_in_days=request.expires_in_days,
+            )
         )
-    )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return response.model_dump(mode="json")
 
 

--- a/src/ad_seller/interfaces/cli/main.py
+++ b/src/ad_seller/interfaces/cli/main.py
@@ -314,17 +314,20 @@ def create_operator_key(
     """
     from ...auth.api_key_service import ApiKeyService
     from ...models.api_key import OperatorApiKeyCreateRequest
-    from ...storage.factory import get_storage
+    from ...storage.factory import close_storage, get_storage
 
     async def _mint():
-        storage = await get_storage()
-        service = ApiKeyService(storage)
-        return await service.create_operator_key(
-            OperatorApiKeyCreateRequest(
-                label=label,
-                expires_in_days=expires_in_days,
+        try:
+            storage = await get_storage()
+            service = ApiKeyService(storage)
+            return await service.create_operator_key(
+                OperatorApiKeyCreateRequest(
+                    label=label,
+                    expires_in_days=expires_in_days,
+                )
             )
-        )
+        finally:
+            await close_storage()
 
     try:
         response = asyncio.run(_mint())
@@ -343,6 +346,119 @@ def create_operator_key(
         "  Authorization: Bearer <key>   or   X-Api-Key: <key>\n"
         "Run this with the same storage config (.env) as the server so the\n"
         "key lands in the storage backend the server reads."
+    )
+
+
+@app.command("list-operator-keys")
+def list_operator_keys(
+    include_inactive: bool = typer.Option(
+        False,
+        "--include-inactive",
+        "-a",
+        help="Include revoked/expired operator keys",
+    ),
+):
+    """List OPERATOR-role API keys (metadata only, no secrets).
+
+    Reads directly from storage — same bootstrap surface as
+    ``create-operator-key`` / ``delete-operator-key``. Secrets are never
+    shown (they are only printed once at creation time).
+    """
+    from ...auth.api_key_service import ApiKeyService
+    from ...storage.factory import close_storage, get_storage
+
+    async def _list():
+        try:
+            storage = await get_storage()
+            service = ApiKeyService(storage)
+            return await service.list_operator_keys(include_inactive=include_inactive)
+        finally:
+            await close_storage()
+
+    try:
+        keys = asyncio.run(_list())
+    except Exception as exc:
+        console.print(f"[red]Failed to list operator keys: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if not keys:
+        console.print("[yellow]No operator keys found.[/yellow]")
+        if not include_inactive:
+            console.print("Tip: pass --include-inactive to show revoked/expired keys.")
+        return
+
+    table = Table(title="Operator API Keys")
+    table.add_column("Key ID", style="cyan")
+    table.add_column("Label")
+    table.add_column("Active")
+    table.add_column("Created")
+    table.add_column("Expires")
+    table.add_column("Last used")
+    table.add_column("Uses", justify="right")
+
+    for info in keys:
+        table.add_row(
+            info.key_id,
+            info.label or "",
+            "[green]yes[/green]" if info.is_active else "[red]no[/red]",
+            info.created_at.isoformat() if info.created_at else "",
+            info.expires_at.isoformat() if info.expires_at else "never",
+            info.last_used_at.isoformat() if info.last_used_at else "never",
+            str(info.use_count),
+        )
+
+    console.print(table)
+
+
+@app.command("delete-operator-key")
+def delete_operator_key(
+    label: Optional[str] = typer.Option(
+        None,
+        "--label",
+        "-l",
+        help="Label of the active operator key to revoke",
+    ),
+    key_id: Optional[str] = typer.Option(
+        None,
+        "--key-id",
+        "-k",
+        help="Key id to revoke (e.g. key-a1b2c3d4); takes precedence over --label",
+    ),
+):
+    """Revoke an OPERATOR-role API key directly in storage (bootstrap).
+
+    Soft-revokes the key so it can no longer authenticate, and frees its
+    label for reuse by ``ad-seller create-operator-key``. Provide
+    ``--key-id`` or ``--label`` (key-id wins if both are set). Buyer keys
+    are refused — use ``DELETE /auth/api-keys/{key_id}`` for those.
+    """
+    from ...auth.api_key_service import ApiKeyService
+    from ...storage.factory import close_storage, get_storage
+
+    if not key_id and not label:
+        console.print("[red]Provide --key-id or --label[/red]")
+        raise typer.Exit(1)
+
+    async def _revoke():
+        try:
+            storage = await get_storage()
+            service = ApiKeyService(storage)
+            return await service.delete_operator_key(key_id=key_id, label=label)
+        finally:
+            await close_storage()
+
+    try:
+        info = asyncio.run(_revoke())
+    except Exception as exc:
+        console.print(f"[red]Failed to delete operator key: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    console.print(Panel("Operator API key revoked", title="Bootstrap"))
+    console.print(f"Key ID:  [cyan]{info.key_id}[/cyan]")
+    console.print(f"Label:   {info.label}")
+    console.print(
+        "\nThe key can no longer authenticate. Its label may be reused with\n"
+        "`ad-seller create-operator-key --label ...`."
     )
 
 
@@ -401,11 +517,16 @@ def chat():
             break
 
 
-if __name__ == "__main__":
-    import os
+def main():
+    """Console-script entrypoint: hard-exit after typer returns.
 
-    try:
-        app()
-    except SystemExit as e:
-        os._exit(e.code if isinstance(e.code, int) else 0)
-    os._exit(0)
+    Bypass telemetry/atexit hangs from transitive deps (crewai/chromadb/
+    posthog/opentelemetry). See ``ad_seller._telemetry_shim``.
+    """
+    from ..._telemetry_shim import force_exit_after
+
+    force_exit_after(app)()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_operator_auth.py
+++ b/tests/unit/test_operator_auth.py
@@ -48,6 +48,7 @@ from httpx import ASGITransport  # noqa: E402
 
 from ad_seller.interfaces.api.main import app  # noqa: E402
 from ad_seller.models.api_key import (  # noqa: E402
+    API_KEY_INDEX_PREFIX,
     API_KEY_STORAGE_PREFIX,
     ApiKeyRecord,
     ApiKeyRole,
@@ -77,8 +78,19 @@ def client():
     return httpx.AsyncClient(transport=transport, base_url="http://test")
 
 
-def _seed_key(store, *, role=ApiKeyRole.BUYER, key_id="key-test"):
-    """Seed a valid API key record with the given role; return the raw key."""
+def _seed_key(
+    store,
+    *,
+    role=ApiKeyRole.BUYER,
+    key_id="key-test",
+    label: str | None = None,
+    revoked: bool = False,
+):
+    """Seed a valid API key record with the given role; return the raw key.
+
+    Also maintains ``api_key_list`` / index so ``list_keys()`` sees the seed
+    (needed for operator-label uniqueness checks).
+    """
     raw_key = generate_api_key()
     key_hash = hash_api_key(raw_key)
     record = ApiKeyRecord(
@@ -87,9 +99,14 @@ def _seed_key(store, *, role=ApiKeyRole.BUYER, key_id="key-test"):
         key_prefix_hint=raw_key[:12] + "...",
         identity=BuyerIdentity(agency_id="agy-1", agency_name="Acme"),
         role=role,
-        label=f"{role.value} test key",
+        label=label if label is not None else f"{role.value} test key",
+        revoked=revoked,
     )
     store[f"{API_KEY_STORAGE_PREFIX}{key_hash}"] = record.model_dump(mode="json")
+    store[f"{API_KEY_INDEX_PREFIX}{key_id}"] = key_hash
+    all_keys = store.get("api_key_list") or []
+    all_keys.append(key_id)
+    store["api_key_list"] = all_keys
     return raw_key
 
 
@@ -176,6 +193,49 @@ class TestApiKeyEndpointsRequireOperator:
         # Empty BuyerIdentity — operator keys carry no seat/agency/advertiser.
         assert body["identity"].get("agency_id") in (None, "")
         assert body["identity"].get("seat_id") in (None, "")
+
+    async def test_duplicate_operator_label_is_409(self, client, mock_storage):
+        """Active operator keys may not share a label."""
+        raw_key = _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Primary operator",
+        )
+        with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+            resp = await client.post(
+                "/auth/api-keys/operator",
+                json={"label": "Primary operator"},
+                headers=_auth(raw_key),
+            )
+        assert resp.status_code == 409
+        assert "Primary operator" in resp.text
+        assert "key-op-1" in resp.text
+
+    async def test_revoked_operator_label_may_be_reused(self, client, mock_storage):
+        """Revoked operator keys do not block reusing their label."""
+        raw_key = _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-auth",
+            label="auth-only",
+        )
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-revoked",
+            label="Reusable label",
+            revoked=True,
+        )
+        with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+            resp = await client.post(
+                "/auth/api-keys/operator",
+                json={"label": "Reusable label"},
+                headers=_auth(raw_key),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["label"] == "Reusable label"
+        assert resp.json()["role"] == "operator"
 
     async def test_buyer_create_endpoint_ignores_role_field(self, client, mock_storage):
         """role is not on CreateApiKeyRequest — extra fields are ignored; always buyer."""
@@ -295,7 +355,12 @@ class TestCliBootstrap:
     def test_create_operator_key_mints_operator_role(self, mock_storage):
         from ad_seller.interfaces.cli.main import create_operator_key
 
-        with patch("ad_seller.storage.factory.get_storage", return_value=mock_storage):
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch(
+                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
+            ) as close_mock,
+        ):
             create_operator_key(label="bootstrap test", expires_in_days=None)
 
         records = [
@@ -307,6 +372,283 @@ class TestCliBootstrap:
         # Operator keys carry an empty BuyerIdentity (no seat/agency).
         assert not records[0]["identity"].get("agency_id")
         assert not records[0]["identity"].get("seat_id")
+        close_mock.assert_awaited_once()
+
+    def test_duplicate_label_exits_nonzero_and_closes_storage(self, mock_storage):
+        import typer
+
+        from ad_seller.interfaces.cli.main import create_operator_key
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-existing",
+            label="bootstrap test",
+        )
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch(
+                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
+            ) as close_mock,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            create_operator_key(label="bootstrap test", expires_in_days=None)
+
+        assert exc_info.value.exit_code == 1
+        close_mock.assert_awaited_once()
+
+    def test_different_label_succeeds_after_existing_operator(self, mock_storage):
+        from ad_seller.interfaces.cli.main import create_operator_key
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-existing",
+            label="Primary operator",
+        )
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock),
+        ):
+            create_operator_key(label="Secondary operator", expires_in_days=None)
+
+        labels = {
+            v["label"]
+            for k, v in mock_storage._store.items()
+            if k.startswith(API_KEY_STORAGE_PREFIX)
+        }
+        assert labels == {"Primary operator", "Secondary operator"}
+
+    def test_delete_operator_key_by_label_closes_storage(self, mock_storage):
+        from ad_seller.interfaces.cli.main import delete_operator_key
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Primary operator",
+        )
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch(
+                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
+            ) as close_mock,
+        ):
+            delete_operator_key(label="Primary operator", key_id=None)
+
+        record = next(
+            v
+            for k, v in mock_storage._store.items()
+            if k.startswith(API_KEY_STORAGE_PREFIX)
+        )
+        assert record["revoked"] is True
+        close_mock.assert_awaited_once()
+
+    def test_delete_operator_key_missing_args_exits(self, mock_storage):
+        import typer
+
+        from ad_seller.interfaces.cli.main import delete_operator_key
+
+        with pytest.raises(typer.Exit) as exc_info:
+            delete_operator_key(label=None, key_id=None)
+        assert exc_info.value.exit_code == 1
+
+    def test_delete_then_recreate_same_label(self, mock_storage):
+        from ad_seller.interfaces.cli.main import create_operator_key, delete_operator_key
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-old",
+            label="Primary operator",
+        )
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock),
+        ):
+            delete_operator_key(label="Primary operator", key_id=None)
+            create_operator_key(label="Primary operator", expires_in_days=None)
+
+        active = [
+            v
+            for k, v in mock_storage._store.items()
+            if k.startswith(API_KEY_STORAGE_PREFIX) and not v.get("revoked")
+        ]
+        assert len(active) == 1
+        assert active[0]["label"] == "Primary operator"
+        assert active[0]["key_id"] != "key-old"
+
+
+class TestCreateOperatorKeyService:
+    async def test_duplicate_active_label_raises(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+        from ad_seller.models.api_key import OperatorApiKeyCreateRequest
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Ops",
+        )
+        service = ApiKeyService(mock_storage)
+        with pytest.raises(ValueError, match="key-op-1"):
+            await service.create_operator_key(OperatorApiKeyCreateRequest(label="Ops"))
+
+    async def test_revoked_label_may_be_reused(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+        from ad_seller.models.api_key import OperatorApiKeyCreateRequest
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-revoked",
+            label="Ops",
+            revoked=True,
+        )
+        service = ApiKeyService(mock_storage)
+        resp = await service.create_operator_key(OperatorApiKeyCreateRequest(label="Ops"))
+        assert resp.role == ApiKeyRole.OPERATOR
+        assert resp.label == "Ops"
+
+
+class TestListOperatorKeys:
+    async def test_lists_only_active_operator_keys_by_default(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-active",
+            label="Active",
+        )
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-revoked",
+            label="Revoked",
+            revoked=True,
+        )
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.BUYER,
+            key_id="key-buyer",
+            label="Buyer",
+        )
+        service = ApiKeyService(mock_storage)
+        keys = await service.list_operator_keys()
+        assert [k.key_id for k in keys] == ["key-op-active"]
+
+    async def test_include_inactive_returns_revoked(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-active",
+            label="Active",
+        )
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-revoked",
+            label="Revoked",
+            revoked=True,
+        )
+        service = ApiKeyService(mock_storage)
+        keys = await service.list_operator_keys(include_inactive=True)
+        assert {k.key_id for k in keys} == {"key-op-active", "key-op-revoked"}
+
+    def test_cli_lists_and_closes_storage(self, mock_storage):
+        from ad_seller.interfaces.cli.main import list_operator_keys
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Primary operator",
+        )
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch(
+                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
+            ) as close_mock,
+        ):
+            list_operator_keys(include_inactive=False)
+        close_mock.assert_awaited_once()
+
+    def test_cli_empty_list_closes_storage(self, mock_storage):
+        from ad_seller.interfaces.cli.main import list_operator_keys
+
+        with (
+            patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
+            patch(
+                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
+            ) as close_mock,
+        ):
+            list_operator_keys(include_inactive=False)
+        close_mock.assert_awaited_once()
+
+
+class TestDeleteOperatorKeyService:
+    async def test_delete_by_label_revokes_and_frees_label(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+        from ad_seller.models.api_key import OperatorApiKeyCreateRequest
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Ops",
+        )
+        service = ApiKeyService(mock_storage)
+        info = await service.delete_operator_key(label="Ops")
+        assert info.key_id == "key-op-1"
+        assert info.revoked is True
+        assert info.is_active is False
+
+        # Label can be reused after revoke.
+        resp = await service.create_operator_key(OperatorApiKeyCreateRequest(label="Ops"))
+        assert resp.key_id != "key-op-1"
+
+    async def test_delete_by_key_id(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.OPERATOR,
+            key_id="key-op-1",
+            label="Ops",
+        )
+        service = ApiKeyService(mock_storage)
+        info = await service.delete_operator_key(key_id="key-op-1")
+        assert info.revoked is True
+
+    async def test_delete_refuses_buyer_key(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        _seed_key(
+            mock_storage._store,
+            role=ApiKeyRole.BUYER,
+            key_id="key-buyer",
+            label="buyer",
+        )
+        service = ApiKeyService(mock_storage)
+        with pytest.raises(ValueError, match="not an operator key"):
+            await service.delete_operator_key(key_id="key-buyer")
+
+    async def test_delete_missing_label_raises(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        service = ApiKeyService(mock_storage)
+        with pytest.raises(ValueError, match="No active operator key"):
+            await service.delete_operator_key(label="missing")
+
+    async def test_delete_requires_identifier(self, mock_storage):
+        from ad_seller.auth.api_key_service import ApiKeyService
+
+        service = ApiKeyService(mock_storage)
+        with pytest.raises(ValueError, match="key_id or label"):
+            await service.delete_operator_key()
 
 
 class TestOperatorApiKeyCreateRequest:

--- a/tests/unit/test_operator_auth.py
+++ b/tests/unit/test_operator_auth.py
@@ -357,9 +357,7 @@ class TestCliBootstrap:
 
         with (
             patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
-            patch(
-                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
-            ) as close_mock,
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock) as close_mock,
         ):
             create_operator_key(label="bootstrap test", expires_in_days=None)
 
@@ -387,9 +385,7 @@ class TestCliBootstrap:
         )
         with (
             patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
-            patch(
-                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
-            ) as close_mock,
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock) as close_mock,
             pytest.raises(typer.Exit) as exc_info,
         ):
             create_operator_key(label="bootstrap test", expires_in_days=None)
@@ -430,16 +426,12 @@ class TestCliBootstrap:
         )
         with (
             patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
-            patch(
-                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
-            ) as close_mock,
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock) as close_mock,
         ):
             delete_operator_key(label="Primary operator", key_id=None)
 
         record = next(
-            v
-            for k, v in mock_storage._store.items()
-            if k.startswith(API_KEY_STORAGE_PREFIX)
+            v for k, v in mock_storage._store.items() if k.startswith(API_KEY_STORAGE_PREFIX)
         )
         assert record["revoked"] is True
         close_mock.assert_awaited_once()
@@ -569,9 +561,7 @@ class TestListOperatorKeys:
         )
         with (
             patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
-            patch(
-                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
-            ) as close_mock,
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock) as close_mock,
         ):
             list_operator_keys(include_inactive=False)
         close_mock.assert_awaited_once()
@@ -581,9 +571,7 @@ class TestListOperatorKeys:
 
         with (
             patch("ad_seller.storage.factory.get_storage", return_value=mock_storage),
-            patch(
-                "ad_seller.storage.factory.close_storage", new_callable=AsyncMock
-            ) as close_mock,
+            patch("ad_seller.storage.factory.close_storage", new_callable=AsyncMock) as close_mock,
         ):
             list_operator_keys(include_inactive=False)
         close_mock.assert_awaited_once()


### PR DESCRIPTION
## Improve operator key CLI management

### Problem

`ad-seller create-operator-key` had two rough edges after the operator-auth work landed:

1. **Duplicate labels** — creating another operator key with an existing active label succeeded silently, making it hard to tell which key was which.
2. **Process hang** — the command printed the key but never exited. Storage was never closed after `asyncio.run(...)`, and the console-script entrypoint (`ad-seller = ...:app`) skipped the hard `os._exit` that `__main__` used to bypass telemetry atexit hangs.

Operators also had no out-of-band way to **list** or **revoke** operator keys without going through the HTTP API (which itself requires an operator credential).

### What this PR does

**Duplicate active labels**

- `ApiKeyService.create_operator_key` rejects an active (non-revoked, non-expired) operator key with the same label (`ValueError`, includes existing `key_id`).
- `POST /auth/api-keys/operator` maps that to **409 Conflict**.
- Revoked/expired labels may be reused. Buyer keys are unaffected.

**CLI exits cleanly**

- `create-operator-key` (and the new commands) always `close_storage()` in a `finally`.
- Console script entrypoint is now `ad_seller.interfaces.cli.main:main`, wrapped with `force_exit_after` so `ad-seller` hard-exits like `__main__`.

**Bootstrap CLI surface**

| Command | Purpose |
|---------|---------|
| `ad-seller create-operator-key` | Mint (unchanged, plus label uniqueness) |
| `ad-seller list-operator-keys [--include-inactive]` | List operator keys (metadata only) |
| `ad-seller delete-operator-key --label …` / `--key-id …` | Soft-revoke an operator key; frees the label |

`delete-operator-key` refuses buyer keys (use `DELETE /auth/api-keys/{key_id}` for those).

### Docs

Updated bootstrap sections in `docs/api/authentication.md`, `docs/guides/agent-management.md`, and `docs/guides/developer-setup.md`.

### Test plan

- [ ] `ad-seller create-operator-key --label "Ops"` twice → second fails with clear error; process exits
- [ ] `ad-seller list-operator-keys` shows the active key; `--include-inactive` shows revoked too
- [ ] `ad-seller delete-operator-key --label "Ops"` then recreate with the same label succeeds
- [ ] `POST /auth/api-keys/operator` with a duplicate active label returns 409
- [ ] Reinstall entrypoint if needed: `pip install -e .`
- [ ] `pytest tests/unit/test_operator_auth.py`