### PR TITLE
test: stop stubbing discovery_inquiry_flow, restore real coverage

### DIFF
--- a/tests/integration/test_deal_flow_e2e.py
+++ b/tests/integration/test_deal_flow_e2e.py
@@ -7,9 +7,7 @@ Tests the key flow components with mocked external dependencies:
 - Approval gate integration
 """
 
-import importlib
-import sys
-
+import ad_seller.flows.deal_request_flow as deal_request_flow_module
 from ad_seller.models.buyer_identity import BuyerContext, BuyerIdentity
 from ad_seller.models.core import DealType, PricingModel
 from ad_seller.models.flow_state import (
@@ -17,46 +15,6 @@ from ad_seller.models.flow_state import (
 )
 
 from .conftest import InMemoryStorage, make_settings
-
-
-def _get_deal_request_flow_class():
-    """Import DealRequestFlow directly from its module, bypassing flows/__init__.py
-    which triggers discovery_inquiry_flow (broken with current crewai version)."""
-    mod_name = "ad_seller.flows.deal_request_flow"
-    if mod_name in sys.modules:
-        return sys.modules[mod_name].DealRequestFlow
-
-    # Ensure the parent package 'ad_seller.flows' exists in sys.modules
-    # as a stub so that find_spec / relative imports work, without
-    # executing the __init__.py that pulls in the broken module.
-    parent_name = "ad_seller.flows"
-    original_parent = sys.modules.get(parent_name)
-    installed_stub = False
-    if original_parent is None:
-        import types
-
-        import ad_seller  # noqa: F401
-
-        stub = types.ModuleType(parent_name)
-        stub.__path__ = [str(importlib.resources.files("ad_seller").joinpath("flows"))]
-        stub.__package__ = parent_name
-        sys.modules[parent_name] = stub
-        installed_stub = True
-
-    spec = importlib.util.find_spec(mod_name)
-    if spec is None:
-        raise ImportError(f"Cannot find {mod_name}")
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[mod_name] = mod
-    spec.loader.exec_module(mod)
-
-    # Remove the stub so other tests that import ad_seller.flows get the real
-    # module (with ProductSetupFlow etc.) instead of a bare stub.
-    if installed_stub:
-        del sys.modules[parent_name]
-
-    return mod.DealRequestFlow
-
 
 # ============================================================================
 # Pricing Engine
@@ -139,7 +97,7 @@ class TestDealRequestFlowE2E:
 
     def _make_state(self, request_text, buyer_context=None, seller_org="INTEG"):
         """Create a DealRequestState manually and return (module, state)."""
-        mod = sys.modules["ad_seller.flows.deal_request_flow"]
+        mod = deal_request_flow_module
         state = mod.DealRequestState(
             flow_id="test-flow-001",
             flow_type="deal_request",
@@ -152,7 +110,6 @@ class TestDealRequestFlowE2E:
 
     async def _run_steps(self, request_text, buyer_context=None, seller_org="INTEG"):
         """Run the flow steps manually in sequence on a DealRequestState."""
-        _get_deal_request_flow_class()  # ensure module is loaded
         mod, state = self._make_state(request_text, buyer_context, seller_org)
 
         settings = make_settings(seller_organization_id=seller_org)

--- a/tests/integration/test_packages_audience_filter.py
+++ b/tests/integration/test_packages_audience_filter.py
@@ -31,10 +31,9 @@ from __future__ import annotations
 import sys
 from types import ModuleType
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before importing main, mirroring test_quote_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_agentic_audience_match.py
+++ b/tests/unit/test_agentic_audience_match.py
@@ -22,7 +22,6 @@ import pytest
 
 # Stub broken flow modules before importing main, mirroring sibling tests.
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_approval_gates.py
+++ b/tests/unit/test_approval_gates.py
@@ -21,10 +21,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_audience_plan_validation.py
+++ b/tests/unit/test_audience_plan_validation.py
@@ -24,7 +24,6 @@ import pytest
 
 # Stub broken flow modules before importing other ad_seller bits.
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_auth_header_binding.py
+++ b/tests/unit/test_auth_header_binding.py
@@ -24,10 +24,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version mismatch)
-# before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_avails_contract_adoption.py
+++ b/tests/unit/test_avails_contract_adoption.py
@@ -27,10 +27,9 @@ from unittest.mock import patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_avails_endpoint.py
+++ b/tests/unit/test_avails_endpoint.py
@@ -20,10 +20,9 @@ from unittest.mock import patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_avails_spec_dialect.py
+++ b/tests/unit/test_avails_spec_dialect.py
@@ -32,10 +32,9 @@ from unittest.mock import patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_capability_audience_block.py
+++ b/tests/unit/test_capability_audience_block.py
@@ -32,11 +32,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before importing main, mirroring the pattern in
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 # test_quote_endpoints.py.
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_change_request.py
+++ b/tests/unit/test_change_request.py
@@ -11,7 +11,6 @@ import pytest
 
 # Stub broken flow modules
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_csv_catalog_coherence.py
+++ b/tests/unit/test_csv_catalog_coherence.py
@@ -31,10 +31,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_issue34_catalog_fixes.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_deal_booking_endpoints.py
+++ b/tests/unit/test_deal_booking_endpoints.py
@@ -12,9 +12,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version mismatch)
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_deal_booking_snapshot.py
+++ b/tests/unit/test_deal_booking_snapshot.py
@@ -28,10 +28,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Mirrors the pattern in tests/unit/test_deal_booking_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_deal_performance_gam.py
+++ b/tests/unit/test_deal_performance_gam.py
@@ -301,13 +301,11 @@ class TestPerformanceEndpointEndToEnd:
         import sys
         from types import ModuleType
 
-        # Stub broken flow modules (pre-existing @listen() bugs with CrewAI
-        # version mismatch) before ad_seller.flows import — same pattern as
-        # test_avails_endpoint.py.
-        for _mod_name in (
-            "ad_seller.flows.discovery_inquiry_flow",
-            "ad_seller.flows.execution_activation_flow",
-        ):
+        # Stub execution_activation_flow (cancel-scope leak on ad-server
+        # connection failure — issue #60 part 2, unresolved) before
+        # ad_seller.flows import — same pattern as test_avails_endpoint.py.
+        # discovery_inquiry_flow no longer needs stubbing (issue #60 part 1).
+        for _mod_name in ("ad_seller.flows.execution_activation_flow",):
             if _mod_name not in sys.modules:
                 _stub = ModuleType(_mod_name)
                 _cls = _mod_name.rsplit(".", 1)[-1].replace("_", " ").title().replace(" ", "")

--- a/tests/unit/test_default_catalog_enrichment.py
+++ b/tests/unit/test_default_catalog_enrichment.py
@@ -24,10 +24,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used across the unit test suite.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_discovery_inquiry_flow.py
+++ b/tests/unit/test_discovery_inquiry_flow.py
@@ -1,0 +1,122 @@
+# Author: Green Mountain Systems AI Inc.
+# Donated to IAB Tech Lab
+
+"""Real coverage for DiscoveryInquiryFlow and POST /discovery (issue #60 part 1).
+
+Every test file that touched ad_seller.flows used to stub this module out
+before import, citing a "pre-existing @listen() bug with CrewAI version
+mismatch" that dated to when crewai was pinned at >=0.86.0. crewai is
+>=1.14.4 now, the flow runs cleanly end to end, and DiscoveryInquiryFlow
+backs a live endpoint (POST /discovery, products.py:201) -- so the stub
+wasn't just hiding dead code, it was hiding a served API path. See issue
+#60 for the full investigation.
+
+These tests run the real flow, not a stub.
+"""
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from ad_seller.flows.discovery_inquiry_flow import DiscoveryInquiryFlow
+from ad_seller.interfaces.api.main import _get_optional_api_key_record, app
+from ad_seller.models.buyer_identity import BuyerContext, BuyerIdentity
+from ad_seller.models.core import DealType, PricingModel
+from ad_seller.models.flow_state import ProductDefinition
+
+
+def _make_product(product_id="ctv-premium-sports", inventory_type="ctv"):
+    return ProductDefinition(
+        product_id=product_id,
+        name="Premium CTV - Sports",
+        inventory_type=inventory_type,
+        supported_deal_types=[DealType.PREFERRED_DEAL],
+        supported_pricing_models=[PricingModel.CPM],
+        base_cpm=35.0,
+        floor_cpm=28.0,
+        minimum_impressions=100000,
+    )
+
+
+def _products():
+    return {"ctv-premium-sports": _make_product()}
+
+
+class TestDiscoveryInquiryFlowRouting:
+    """The flow's own routing logic, run for real -- no stub in the way."""
+
+    @pytest.mark.parametrize(
+        "query, expected_type",
+        [
+            ("show me what you have", "catalog"),
+            ("how much does this cost?", "pricing"),
+            ("what CPM for CTV?", "pricing"),
+            ("what inventory is available?", "availability"),
+            ("how many impressions do you have?", "availability"),
+            ("what audience targeting do you support?", "targeting"),
+        ],
+    )
+    def test_query_routes_to_expected_response_type(self, query, expected_type):
+        flow = DiscoveryInquiryFlow()
+        response = flow.query(query=query, buyer_context=None, products=_products())
+        assert flow.state.response_type == expected_type
+        assert response is not None
+
+    def test_public_buyer_gets_price_range_not_exact_price(self):
+        flow = DiscoveryInquiryFlow()
+        response = flow.query(
+            query="how much does CTV cost?", buyer_context=None, products=_products()
+        )
+        assert flow.state.response_type == "pricing"
+        assert response is not None
+
+    def test_authenticated_buyer_context_is_accepted(self):
+        ctx = BuyerContext(
+            identity=BuyerIdentity(agency_id="agency-1", agency_name="Test Agency"),
+            is_authenticated=True,
+        )
+        flow = DiscoveryInquiryFlow()
+        response = flow.query(query="what's available?", buyer_context=ctx, products=_products())
+        assert flow.state.response_type == "availability"
+        assert response is not None
+
+    def test_empty_catalog_does_not_crash(self):
+        flow = DiscoveryInquiryFlow()
+        response = flow.query(query="show me your catalog", buyer_context=None, products={})
+        assert response is not None
+
+
+class TestDiscoveryEndpointRealFlow:
+    """POST /discovery through the real FastAPI app -- the real
+    DiscoveryInquiryFlow runs, nothing mocked."""
+
+    @pytest.fixture
+    def client(self):
+        app.dependency_overrides[_get_optional_api_key_record] = lambda: None
+        transport = ASGITransport(app=app)
+        c = httpx.AsyncClient(transport=transport, base_url="http://test")
+        yield c
+        app.dependency_overrides.clear()
+
+    async def test_discovery_query_returns_200(self, client):
+        async with client as c:
+            resp = await c.post("/discovery", json={"query": "what inventory do you have?"})
+        assert resp.status_code == 200, resp.text
+
+    async def test_discovery_pricing_query_returns_200(self, client):
+        async with client as c:
+            resp = await c.post("/discovery", json={"query": "how much does CTV cost?"})
+        assert resp.status_code == 200, resp.text
+
+    async def test_discovery_query_with_buyer_tier_returns_200(self, client):
+        async with client as c:
+            resp = await c.post(
+                "/discovery",
+                json={"query": "what's available?", "buyer_tier": "agency", "agency_id": "ag-1"},
+            )
+        assert resp.status_code == 200, resp.text
+
+    async def test_discovery_missing_query_is_422(self, client):
+        async with client as c:
+            resp = await c.post("/discovery", json={})
+        assert resp.status_code == 422

--- a/tests/unit/test_endpoint_no_flow_kickoff.py
+++ b/tests/unit/test_endpoint_no_flow_kickoff.py
@@ -25,10 +25,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version mismatch).
-# Same pattern used in test_deal_booking_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_issue34_catalog_fixes.py
+++ b/tests/unit/test_issue34_catalog_fixes.py
@@ -34,10 +34,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_endpoint_no_flow_kickoff.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_linear_tv.py
+++ b/tests/unit/test_linear_tv.py
@@ -738,8 +738,7 @@ class TestTrafficTools:
 class TestClassificationHelpers:
     """Tests for linear TV classification in product setup flow.
 
-    These test the static methods directly without importing the flow module
-    (which has a pre-existing broken import in discovery_inquiry_flow.py).
+    These test the static methods directly without importing the flow module.
     """
 
     def test_classify_ad_formats(self):

--- a/tests/unit/test_negotiation_cold_start.py
+++ b/tests/unit/test_negotiation_cold_start.py
@@ -35,10 +35,9 @@ from fastapi import HTTPException
 # as test_modern_agentic_capabilities.py (no LLM call is ever made here).
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_deal_booking_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_negotiation_lowball_counter.py
+++ b/tests/unit/test_negotiation_lowball_counter.py
@@ -38,10 +38,9 @@ import pytest
 # as test_negotiation_cold_start.py (no LLM call is ever made here).
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_negotiation_cold_start.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_negotiation_message_endpoint.py
+++ b/tests/unit/test_negotiation_message_endpoint.py
@@ -15,9 +15,9 @@ import sys
 from types import ModuleType
 from unittest.mock import AsyncMock, patch
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI mismatch).
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_operator_auth.py
+++ b/tests/unit/test_operator_auth.py
@@ -30,10 +30,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_optional_startup_key.py
+++ b/tests/unit/test_optional_startup_key.py
@@ -27,10 +27,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_proposal_flow_time_budget.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_order_audit.py
+++ b/tests/unit/test_order_audit.py
@@ -11,7 +11,6 @@ import pytest
 
 # Stub broken flow modules
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_order_endpoints.py
+++ b/tests/unit/test_order_endpoints.py
@@ -11,7 +11,6 @@ import pytest
 
 # Stub broken flow modules
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_proposal_avails_grounding.py
+++ b/tests/unit/test_proposal_avails_grounding.py
@@ -38,10 +38,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # as test_negotiation_lowball_counter.py (no LLM call is ever made here).
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_negotiation_lowball_counter.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_proposal_error_taxonomy.py
+++ b/tests/unit/test_proposal_error_taxonomy.py
@@ -35,10 +35,9 @@ import pytest
 # as test_proposal_flow_time_budget.py (no LLM call is ever made here).
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_negotiation_cold_start.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_proposal_flow_time_budget.py
+++ b/tests/unit/test_proposal_flow_time_budget.py
@@ -32,10 +32,9 @@ import pytest
 # as test_negotiation_cold_start.py (no LLM call is ever made here).
 os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-unit-tests")
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_negotiation_cold_start.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_quote_availability_grounding.py
+++ b/tests/unit/test_quote_availability_grounding.py
@@ -26,10 +26,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used across the unit test suite.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_quote_endpoints.py
+++ b/tests/unit/test_quote_endpoints.py
@@ -18,10 +18,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version mismatch)
-# before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_route_shadowing.py
+++ b/tests/unit/test_route_shadowing.py
@@ -24,10 +24,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) — mirrors tests/unit/test_deal_booking_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_service_layer.py
+++ b/tests/unit/test_service_layer.py
@@ -20,10 +20,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch). Same pattern used in test_deal_booking_endpoints.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:

--- a/tests/unit/test_trust_tier_verification.py
+++ b/tests/unit/test_trust_tier_verification.py
@@ -29,10 +29,9 @@ import sys
 from types import ModuleType
 from unittest.mock import AsyncMock, patch
 
-# Stub broken flow modules (pre-existing @listen() bugs with CrewAI version
-# mismatch) before any import of ad_seller.flows triggers __init__.py.
+# Stub execution_activation_flow (cancel-scope leak on ad-server
+# connection failure, unresolved -- issue #60 part 2).
 _broken_flows = [
-    "ad_seller.flows.discovery_inquiry_flow",
     "ad_seller.flows.execution_activation_flow",
 ]
 for _mod_name in _broken_flows:


### PR DESCRIPTION
## Summary

Part 1 of #60 (green-lit by @atc964 on the issue).

The `"pre-existing @listen() bugs with CrewAI version mismatch"` stub that every `ad_seller.flows`-touching test file carried for `discovery_inquiry_flow` dates to when `crewai` was pinned at `>=0.86.0` (commit `530df34`, March 2026). It's `>=1.14.4` now (resolves to `1.15.2`) — a major version bump. Verified on the issue that the flow runs cleanly end-to-end on the current version, including the exact production call path (`flow.query()`'s sync `self.kickoff()` invoked from inside an async FastAPI handler).

This wasn't just stale test hygiene — `DiscoveryInquiryFlow` backs a live endpoint (`POST /discovery`, `products.py:201`), so the blanket stub meant that endpoint had zero real test coverage for as long as the stub existed (`grep -rl "DiscoveryInquiryFlow" tests/` returned nothing before this PR).

`execution_activation_flow` stays stubbed — it has a separate, real bug (a cancel-scope leak in an MCP client cleanup path, not the `@listen()` issue the old comment claimed) that's tracked as #60 part 2 and will be fixed independently.

## Changes

- Removed the `discovery_inquiry_flow` entry from the `_broken_flows` stub list in all 33 test files that had it. `execution_activation_flow` entries are untouched.
- Simplified `test_deal_flow_e2e.py`: its `_get_deal_request_flow_class()` helper existed solely to bypass `flows/__init__.py` via manual `sys.modules` surgery so importing `DealRequestFlow` wouldn't also trigger `discovery_inquiry_flow`. With the stub gone that's unnecessary — replaced with a plain module import (net -41 lines in that file alone).
- Fixed the stale docstring in `test_linear_tv.py` making the same claim.
- Added `tests/unit/test_discovery_inquiry_flow.py`: the flow's own routing logic across all four response types (`catalog`/`pricing`/`availability`/`targeting`) run for real, plus `POST /discovery` exercised through the actual FastAPI app with the real flow — not mocked — closing the exact coverage gap the issue found.

## Test plan

Full suite: 1491 passed, 28 skipped (pre-existing, unrelated to this change), no regressions. `ruff check` / `format --check` clean.

Part of #60.